### PR TITLE
Fix 'offset is out of bounds' crash on large selections (Ctrl+A)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 dist
 node_modules
+.parcel-cache

--- a/background.js
+++ b/background.js
@@ -1,100 +1,5 @@
 import * as tf from '@tensorflow/tfjs';
-
-const RAFE = '\u05BF';
-const niqqud_array = ['', '', 'ְ', 'ֱ', 'ֲ', 'ֳ', 'ִ', 'ֵ', 'ֶ', 'ַ', 'ָ', 'ֹ', 'ֺ', 'ֻ', 'ּ', 'ַ'];
-const dagesh_array = ['', '', 'ּ'];
-const sin_array = ['', '', 'ׁ', 'ׂ'];
-
-const HEBREW_LETTERS = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט', 'י', 'ך', 'כ', 'ל', 'ם', 'מ', 'ן', 'נ', 'ס', 'ע', 'ף',
-    'פ', 'ץ', 'צ', 'ק', 'ר', 'ש', 'ת'];
-const VALID_LETTERS = [' ', '!', '"', "'", '(', ')', ',', '-', '.', ':', ';', '?'].concat(HEBREW_LETTERS);
-const SPECIAL_TOKENS = ['H', 'O', '5'];
-const ALL_TOKENS = [''].concat(SPECIAL_TOKENS).concat(VALID_LETTERS);
-
-function normalize(c) {
-    if (c === '\n' || c === '\t') return ' ';
-    if (VALID_LETTERS.includes(c)) return c;
-    if (['־', '‒', '–', '—', '―', '−'].includes(c)) return '-';
-    if (c === '[') return '(';
-    if (c === ']') return ')';
-    if (['´', '‘', '’'].includes(c)) return "'";
-    if (['“', '”', '״'].includes(c)) return '"';
-    if ('0123456789'.includes(c)) return '5';
-    if (c === '…') return ',';
-    if (['ײ', 'װ', 'ױ'].includes(c)) return 'H';
-    return 'O';
-}
-
-function split_to_rows(text, MAXLEN) {
-    const space = ALL_TOKENS.indexOf(" ");
-    const arr = text.split(" ").map(s => Array.from(s).map(c => ALL_TOKENS.indexOf(c)));
-    let line = [];
-    const rows = [line];
-    for (let i = 0; i < arr.length; i++) {
-        if (arr[i].length + line.length + 1 > MAXLEN) {
-            while (line.length < MAXLEN)
-                line.push(0);
-            line = [];
-            rows.push(line);
-        }
-        line.push(...arr[i]);
-        line.push(space);
-    }
-    while (line.length < MAXLEN)
-        line.push(0);
-    return rows;
-}
-
-function can_dagesh(letter) {
-    return ('בגדהוזטיכלמנספצקשת' + 'ךף').includes(letter);
-}
-
-function can_sin(letter) {
-    return letter === 'ש';
-}
-
-function can_niqqud(letter) {
-    return ('אבגדהוזחטיכלמנסעפצקרשת' + 'ךן').includes(letter);
-}
-
-function prediction_to_text(input, prediction, undotted_text) {
-
-    function from_categorical(arr) {
-        return arr.argMax(-1).reshape([-1]).arraySync().filter((e, i) => input[i] > 0);
-    }
-
-    const [niqqud, dagesh, sin] = prediction;
-    const len = undotted_text.length;
-    const niqqud_result = from_categorical(niqqud);
-    const dagesh_result = from_categorical(dagesh);
-    const sin_result = from_categorical(sin);
-
-    let output = [];
-    for (let i = 0; i < len; i++) {
-        const c = undotted_text[i];
-        const fresh = {char: c, niqqud: '', dagesh: '', sin: ''};
-
-        if (HEBREW_LETTERS.includes(c)) {
-            if (can_niqqud(c))
-                fresh.niqqud = niqqud_array[niqqud_result[i]];
-            if (can_dagesh(c))
-                fresh.dagesh = dagesh_array[dagesh_result[i]];
-            if (can_sin(c))
-                fresh.sin = sin_array[sin_result[i]];
-        }
-        output.push(fresh);
-    }
-    return output;
-}
-
-function remove_niqqud(text) {
-    return text.replace(/[\u0591-\u05C7]/g, '');
-}
-
-function to_text(item) {
-    const c = item.char === '\n' ? '\r\n' : item.char;
-    return c + (item.dagesh || '') + (item.sin || '') + (item.niqqud || '');
-}
+import {diacritize} from './text_encoding.mjs';
 
 async function load_model() {
     const model = await tf.loadLayersModel(chrome.runtime.getURL("model/model.json"));
@@ -117,14 +22,7 @@ chrome.runtime.onMessage.addListener(
     function (request, sender, sendResponse) {
 
         model.then(function (res) {
-            const undotted_text = remove_niqqud(request.text);
-            const input = split_to_rows(undotted_text.replace(/./gms, normalize), 90);
-            const prediction = res.predict(tf.tensor2d(input), {batchSize: 64});
-
-            let result = prediction_to_text([].concat(...input), prediction, undotted_text);
-
-            result = result.map(to_text).join("")
-            sendResponse({processed: result});
+            sendResponse({processed: diacritize(tf, res, request.text)});
 
         }, function (err) {
             sendResponse({processed: 'error'});
@@ -132,4 +30,3 @@ chrome.runtime.onMessage.addListener(
         return true
     }
 );
-

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tensorflow/tfjs": "^4.16.0"
   },
   "scripts": {
+    "test": "node --test \"tests/**/*.test.mjs\"",
     "copy": "cp manifest.json dist/ && cp -R images dist/images && cp -R model dist/model",
     "prebuild": "rm -rf dist",
     "prebuild-dev": "rm -rf dist",

--- a/tests/text_encoding.test.mjs
+++ b/tests/text_encoding.test.mjs
@@ -1,0 +1,136 @@
+import {test, describe, before} from 'node:test';
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import * as tf from '@tensorflow/tfjs';
+import {normalize, split_to_rows, remove_niqqud, diacritize} from '../text_encoding.mjs';
+
+const MAXLEN = 90;
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function encode(text) {
+    return text.replace(/./gms, normalize);
+}
+
+function assertValidRows(rows, text) {
+    // Every row must be exactly MAXLEN, otherwise tf.tensor2d gets ragged
+    // input and the WebGL backend crashes with "offset is out of bounds".
+    for (const row of rows)
+        assert.equal(row.length, MAXLEN, `row length ${row.length} !== ${MAXLEN}`);
+
+    // Alignment invariant used by prediction_to_text: the non-padding tokens,
+    // in order, must be the input text plus exactly one trailing space.
+    // (Each split-consumed delimiter is re-emitted after its word.)
+    const nonPadding = rows.flat().filter(t => t > 0);
+    assert.equal(nonPadding.length, text.length + 1,
+        'non-padding token count must equal text length + 1');
+}
+
+describe('split_to_rows', () => {
+    test('plain Hebrew sentence', () => {
+        const text = encode('הם חלק ממאמצי האגודה הלאומית');
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+    });
+
+    test('empty string', () => {
+        const rows = split_to_rows('', MAXLEN);
+        for (const row of rows) assert.equal(row.length, MAXLEN);
+    });
+
+    test('single word longer than a row (the Ctrl+A crash)', () => {
+        const text = encode('א'.repeat(500));
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+    });
+
+    test('word lengths around the row boundary', () => {
+        for (const n of [1, 88, 89, 90, 91, 179, 180, 181, 269, 270, 271]) {
+            const text = encode('ב'.repeat(n));
+            assertValidRows(split_to_rows(text, MAXLEN), text);
+            const withNeighbours = encode('שלום ' + 'ב'.repeat(n) + ' עולם');
+            assertValidRows(split_to_rows(withNeighbours, MAXLEN), withNeighbours);
+        }
+    });
+
+    test('long word after a partially filled line', () => {
+        const text = encode('קצר ' + 'ג'.repeat(250) + ' סוף');
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+    });
+
+    test('consecutive spaces', () => {
+        const text = encode('שלום   עולם');
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+    });
+
+    test('non-breaking spaces normalize to spaces instead of gluing words', () => {
+        const glued = Array(40).fill('שלום').join(' ');
+        const text = encode(glued);
+        assert.ok(!text.includes('O'), 'nbsp must normalize to a space, not O');
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+    });
+
+    test('full-page-like blob: URLs, digits, punctuation, foreign chars', () => {
+        const blob = [
+            'https://www.ynet.co.il/home/0,7340,L-8,00.html'.repeat(4),
+            'שורה ראשונה של כתבה בעברית עם פיסוק, מספרים 123 ו"מרכאות".',
+            'x'.repeat(300),
+            Array(30).fill('מילה').join(' '),
+            'עוד\tטקסט\nרגיל\r\nכאן',
+        ].join(' ');
+        const text = encode(blob);
+        assertValidRows(split_to_rows(text, MAXLEN), text);
+        // The declared-shape tensor build used by diacritize() must not throw.
+        const rows = split_to_rows(text, MAXLEN);
+        const t = tf.tensor2d(rows, [rows.length, MAXLEN], 'float32');
+        assert.deepEqual(t.shape, [rows.length, MAXLEN]);
+        t.dispose();
+    });
+});
+
+describe('end-to-end with the real model', () => {
+    let model;
+
+    before(async () => {
+        const dir = join(repoRoot, 'model');
+        const modelJSON = JSON.parse(await readFile(join(dir, 'model.json'), 'utf8'));
+        const weightSpecs = modelJSON.weightsManifest.flatMap(g => g.weights);
+        const buffers = await Promise.all(
+            modelJSON.weightsManifest.flatMap(g => g.paths).map(p => readFile(join(dir, p))));
+        const weightData = new Uint8Array(buffers.reduce((a, b) => a + b.length, 0));
+        let offset = 0;
+        for (const b of buffers) {
+            weightData.set(b, offset);
+            offset += b.length;
+        }
+        model = await tf.loadLayersModel(tf.io.fromMemory({
+            modelTopology: modelJSON.modelTopology,
+            weightSpecs,
+            weightData: weightData.buffer,
+        }));
+    });
+
+    test('short sentence gets niqqud', () => {
+        const out = diacritize(tf, model, 'הם חלק ממאמצי האגודה הלאומית');
+        assert.ok(/[ְ-ּ]/.test(out), 'output should contain niqqud marks');
+        assert.equal(remove_niqqud(out), 'הם חלק ממאמצי האגודה הלאומית');
+    });
+
+    test('select-all-like page text with giant unbroken tokens does not crash', () => {
+        const blob = [
+            Array(50).fill('חדשות').join(' '),
+            'https://www.ynet.co.il/home/0,7340,L-8,00.html',
+            'ynetארועיםמבזקיםכלכלהספורטתרבותדיגיטלבריאותוכושרצרכנותנדלןחופשקניוןדעותקריירהיהדותאוכללימודיםאסטרולוגיהמזגאוויר',
+            'כותרת ראשית: דבר מה קרה היום בבוקר.',
+            'עוד פסקה עם טקסט עברי רגיל שאמור לקבל ניקוד תקין.',
+        ].join(' ');
+        const out = diacritize(tf, model, blob);
+        // Structure is preserved: stripping the added niqqud returns the input.
+        assert.equal(remove_niqqud(out), remove_niqqud(blob));
+    });
+
+    test('large multi-batch input (forces predict batching)', () => {
+        const blob = Array(200).fill('הם חלק ממאמצי האגודה הלאומית לשמירת הטבע בישראל').join(' ');
+        const out = diacritize(tf, model, blob);
+        assert.equal(remove_niqqud(out), blob);
+    });
+});

--- a/text_encoding.mjs
+++ b/text_encoding.mjs
@@ -1,0 +1,133 @@
+const RAFE = '\u05BF';
+const niqqud_array = ['', '', 'ְ', 'ֱ', 'ֲ', 'ֳ', 'ִ', 'ֵ', 'ֶ', 'ַ', 'ָ', 'ֹ', 'ֺ', 'ֻ', 'ּ', 'ַ'];
+const dagesh_array = ['', '', 'ּ'];
+const sin_array = ['', '', 'ׁ', 'ׂ'];
+
+const HEBREW_LETTERS = ['א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט', 'י', 'ך', 'כ', 'ל', 'ם', 'מ', 'ן', 'נ', 'ס', 'ע', 'ף',
+    'פ', 'ץ', 'צ', 'ק', 'ר', 'ש', 'ת'];
+const VALID_LETTERS = [' ', '!', '"', "'", '(', ')', ',', '-', '.', ':', ';', '?'].concat(HEBREW_LETTERS);
+const SPECIAL_TOKENS = ['H', 'O', '5'];
+const ALL_TOKENS = [''].concat(SPECIAL_TOKENS).concat(VALID_LETTERS);
+
+function normalize(c) {
+    if (c === '\n' || c === '\t' || c === '\r' || c === '\u00A0') return ' ';
+    if (VALID_LETTERS.includes(c)) return c;
+    if (['־', '‒', '–', '—', '―', '−'].includes(c)) return '-';
+    if (c === '[') return '(';
+    if (c === ']') return ')';
+    if (['´', '‘', '’'].includes(c)) return "'";
+    if (['“', '”', '״'].includes(c)) return '"';
+    if ('0123456789'.includes(c)) return '5';
+    if (c === '…') return ',';
+    if (['ײ', 'װ', 'ױ'].includes(c)) return 'H';
+    return 'O';
+}
+
+function split_to_rows(text, MAXLEN) {
+    const space = ALL_TOKENS.indexOf(" ");
+    const words = text.split(" ").map(s => Array.from(s).map(c => ALL_TOKENS.indexOf(c)));
+    let line = [];
+    const rows = [line];
+
+    function next_row() {
+        while (line.length < MAXLEN)
+            line.push(0);
+        line = [];
+        rows.push(line);
+    }
+
+    for (const word of words) {
+        if (word.length + line.length + 1 > MAXLEN && line.length > 0)
+            next_row();
+        // A single word longer than a row must be split across rows,
+        // otherwise rows come out ragged and the input tensor is corrupt.
+        let offset = 0;
+        while (word.length - offset > MAXLEN - line.length) {
+            const take = MAXLEN - line.length;
+            line.push(...word.slice(offset, offset + take));
+            offset += take;
+            next_row();
+        }
+        line.push(...word.slice(offset));
+        if (line.length === MAXLEN)
+            next_row();
+        line.push(space);
+    }
+    while (line.length < MAXLEN)
+        line.push(0);
+    return rows;
+}
+
+function can_dagesh(letter) {
+    return ('בגדהוזטיכלמנספצקשת' + 'ךף').includes(letter);
+}
+
+function can_sin(letter) {
+    return letter === 'ש';
+}
+
+function can_niqqud(letter) {
+    return ('אבגדהוזחטיכלמנסעפצקרשת' + 'ךן').includes(letter);
+}
+
+function prediction_to_text(input, prediction, undotted_text) {
+
+    function from_categorical(arr) {
+        return arr.argMax(-1).reshape([-1]).arraySync().filter((e, i) => input[i] > 0);
+    }
+
+    const [niqqud, dagesh, sin] = prediction;
+    const len = undotted_text.length;
+    const niqqud_result = from_categorical(niqqud);
+    const dagesh_result = from_categorical(dagesh);
+    const sin_result = from_categorical(sin);
+
+    let output = [];
+    for (let i = 0; i < len; i++) {
+        const c = undotted_text[i];
+        const fresh = {char: c, niqqud: '', dagesh: '', sin: ''};
+
+        if (HEBREW_LETTERS.includes(c)) {
+            if (can_niqqud(c))
+                fresh.niqqud = niqqud_array[niqqud_result[i]];
+            if (can_dagesh(c))
+                fresh.dagesh = dagesh_array[dagesh_result[i]];
+            if (can_sin(c))
+                fresh.sin = sin_array[sin_result[i]];
+        }
+        output.push(fresh);
+    }
+    return output;
+}
+
+function remove_niqqud(text) {
+    return text.replace(/[\u0591-\u05C7]/g, '');
+}
+
+function to_text(item) {
+    const c = item.char === '\n' ? '\r\n' : item.char;
+    return c + (item.dagesh || '') + (item.sin || '') + (item.niqqud || '');
+}
+
+// Full pipeline shared by the service worker and the tests.
+// `tf` is passed in so this module stays import-order independent of the bundle.
+function diacritize(tf, model, text) {
+    const undotted_text = remove_niqqud(text);
+    const input = split_to_rows(undotted_text.replace(/./gms, normalize), 90);
+    const input_tensor = tf.tensor2d(input, [input.length, 90], 'float32');
+    const prediction = model.predict(input_tensor, {batchSize: 64});
+
+    let result = prediction_to_text([].concat(...input), prediction, undotted_text);
+
+    input_tensor.dispose();
+    prediction.forEach(t => t.dispose());
+
+    return result.map(to_text).join("");
+}
+
+export {
+    RAFE, niqqud_array, dagesh_array, sin_array,
+    HEBREW_LETTERS, VALID_LETTERS, SPECIAL_TOKENS, ALL_TOKENS,
+    normalize, split_to_rows, can_dagesh, can_sin, can_niqqud,
+    prediction_to_text, remove_niqqud, to_text, diacritize,
+};


### PR DESCRIPTION
## Problem

Clicking the extension icon after Ctrl+A on a full page (e.g. the ynet homepage) crashed the service worker:

```
RangeError: offset is out of bounds
    at Float32Array.set (<anonymous>)
    at uploadDenseMatrixToTexture (gpgpu_util.ts:197)
    ...
    at background.js:122 (model.predict)
```

## Root cause

`split_to_rows` assumed no space-separated token exceeds MAXLEN (90). Full-page selections contain longer ones — notably because `normalize()` mapped non-breaking spaces (` `, ubiquitous on news sites) to `'O'` instead of `' '`, gluing whole sentences into single giant tokens. An oversized token overflowed its row, producing a **ragged 2D array**. `tf.tensor2d` infers shape from the first row and doesn't deep-validate ragged input in production builds, so the declared shape mismatched the flat data buffer and the WebGL backend wrote out of bounds while uploading the input texture.

Reproduced in Node: an nbsp-glued sentence yields row lengths {90, 200} and a tensor declaring 270 values over a 380-value buffer.

## Fix

- **Split words longer than a row across rows** so every row is exactly MAXLEN (the crash fix)
- Pass an **explicit shape** to `tensor2d` so any future mismatch fails loudly instead of corrupting GPU memory
- Normalize ` ` and `\r` to spaces instead of `'O'`
- **Dispose** input/prediction tensors — previously every click leaked GPU memory in the service worker
- Extract the encoding pipeline into `text_encoding.mjs` so it is unit-testable; `background.js` now just wires Chrome messaging to `diacritize()`

## Testing

`npm test` (new script) — 11 tests, all passing:
- Unit tests: uniform-row and token-alignment invariants across boundary word lengths (89/90/91/179/180/181…), nbsp-glued text, consecutive spaces, empty input, and a ynet-like blob with URLs/digits/tabs
- **End-to-end against the real model in `model/`**: short sentence gets niqqud; a select-all-shaped blob with giant unbroken tokens completes and round-trips exactly (stripping niqqud returns the input); a large multi-batch input exercises the `batchSize: 64` path

`npm run build` passes; verified manually by loading `dist/` as an unpacked extension.
