### PR TITLE
Harden manifest and add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -19,14 +19,14 @@ Implemented as a chain of stacked PRs, one theme at a time.
   Send per-node segments with ids, get per-node results back — no word
   counting. Also excludes `<script>`/`<style>` text nodes (a Ctrl+A range can
   intersect Hebrew-containing JSON-LD, which would get rewritten today).
-- [ ] **Drop the always-on content script.** `manifest.json` injects
+- [x] **Drop the always-on content script.** `manifest.json` injects
   `content.js` into every page and iframe at `document_start`, where it runs
   against an empty selection; the click handler already injects on demand.
-- [ ] **Stop exposing `model/*` to `<all_urls>`.** Only the extension fetches
+- [x] **Stop exposing `model/*` to `<all_urls>`.** Only the extension fetches
   the model; web accessibility just enables fingerprinting.
 - [ ] **Cap and chunk input.** Process rows in chunks so the service worker
   stays responsive on huge selections and progress can be reported.
-- [ ] **CI.** GitHub Actions running `npm test` on every PR.
+- [x] **CI.** GitHub Actions running `npm test` on every PR.
 
 ## 2. Speed
 

--- a/manifest.json
+++ b/manifest.json
@@ -11,16 +11,6 @@
     "activeTab",
     "scripting"
   ],
-  "web_accessible_resources": [
-    {
-      "matches": [
-        "<all_urls>"
-      ],
-      "resources": [
-        "model/*"
-      ]
-    }
-  ],
   "action": {
     "default_icon": {
       "16": "/images/aleph_16.png",
@@ -34,17 +24,5 @@
     "32": "/images/aleph_32.png",
     "48": "/images/aleph_48.png",
     "128": "/images/aleph_128.png"
-  },
-  "content_scripts": [
-    {
-      "matches": [
-        "<all_urls>"
-      ],
-      "js": [
-        "content.js"
-      ],
-      "all_frames": true,
-      "run_at": "document_start"
-    }
-  ]
+  }
 }

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -1,0 +1,30 @@
+import {test, describe} from 'node:test';
+import assert from 'node:assert/strict';
+import {readFile} from 'node:fs/promises';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const manifest = JSON.parse(await readFile(join(repoRoot, 'manifest.json'), 'utf8'));
+
+describe('manifest', () => {
+    test('is manifest v3 with a service worker', () => {
+        assert.equal(manifest.manifest_version, 3);
+        assert.equal(manifest.background.service_worker, 'background.js');
+    });
+
+    test('content script is injected on demand only, not on every page', () => {
+        assert.equal(manifest.content_scripts, undefined,
+            'always-on content_scripts waste memory on every tab and run against an empty selection');
+    });
+
+    test('model files are not web-accessible (fingerprinting surface)', () => {
+        assert.equal(manifest.web_accessible_resources, undefined,
+            'only the extension itself fetches model/*; exposing it lets sites detect the extension');
+    });
+
+    test('permissions stay minimal', () => {
+        assert.deepEqual([...manifest.permissions].sort(),
+            ['activeTab', 'scripting']);
+    });
+});


### PR DESCRIPTION
Stacked on #16.

- Removes the always-on `content_scripts` injection (the click handler already injects on demand; the always-on copy ran against an empty selection on every page/iframe load)
- Removes `web_accessible_resources` for `model/*` (fingerprinting surface; nothing outside the extension needs it)
- Adds GitHub Actions running `npm test` + `npm run build` on PRs and master pushes
- Adds manifest invariant tests so these regressions fail CI

Verified: manifest JSON valid, 4 new tests pass, `npm run build` green.