### PR TITLE
Speed: skip non-Hebrew rows, async readback, warm-up, capped predict size

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 import * as tf from '@tensorflow/tfjs';
-import {diacritize_batch} from './text_encoding.mjs';
+import {diacritize, diacritize_batch} from './text_encoding.mjs';
 
 // Segments are processed in chunks: each chunk is one model.predict call,
 // results stream back per segment, and yielding between chunks keeps the
@@ -8,6 +8,9 @@ const SEGMENTS_PER_CHUNK = 32;
 
 async function load_model() {
     const model = await tf.loadLayersModel(chrome.runtime.getURL("model/model.json"));
+    // Warm-up: the first predict compiles kernels/shaders; pay that cost at
+    // load time instead of on the user's first click.
+    await diacritize(tf, model, 'א');
     return model;
 }
 
@@ -44,7 +47,7 @@ async function handleRequest(port, segments) {
     try {
         for (let i = 0; i < segments.length; i += SEGMENTS_PER_CHUNK) {
             const chunk = segments.slice(i, i + SEGMENTS_PER_CHUNK);
-            const results = diacritize_batch(tf, m, chunk.map(s => s.text));
+            const results = await diacritize_batch(tf, m, chunk.map(s => s.text));
             for (let j = 0; j < chunk.length; j++) {
                 if (!post(port, {type: 'result', id: chunk[j].id, text: results[j]}))
                     return;

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -30,12 +30,12 @@ Implemented as a chain of stacked PRs, one theme at a time.
 
 ## 2. Speed
 
-- [ ] **Skip rows with no Hebrew letters** — the biggest single win. Most of a
+- [x] **Skip rows with no Hebrew letters** — the biggest single win. Most of a
   full-page selection (nav chrome, URLs, digits, Latin) cannot receive niqqud;
   predict only rows containing Hebrew tokens and default the rest.
-- [ ] **Async readback instead of three `arraySync()` stalls** in
+- [x] **Async readback instead of three `arraySync()` stalls** in
   `prediction_to_text`.
-- [ ] **Warm-up predict** after model load so the first click doesn't pay
+- [x] **Warm-up predict** after model load so the first click doesn't pay
   shader/kernel compilation.
 - [ ] **Slim the bundle.** Import `@tensorflow/tfjs-core` / `-layers` / one
   backend instead of the full 1.13 MB `@tensorflow/tfjs`.

--- a/tests/text_encoding.test.mjs
+++ b/tests/text_encoding.test.mjs
@@ -109,13 +109,13 @@ describe('end-to-end with the real model', () => {
         }));
     });
 
-    test('short sentence gets niqqud', () => {
-        const out = diacritize(tf, model, 'הם חלק ממאמצי האגודה הלאומית');
+    test('short sentence gets niqqud', async () => {
+        const out = await diacritize(tf, model, 'הם חלק ממאמצי האגודה הלאומית');
         assert.ok(/[ְ-ּ]/.test(out), 'output should contain niqqud marks');
         assert.equal(remove_niqqud(out), 'הם חלק ממאמצי האגודה הלאומית');
     });
 
-    test('select-all-like page text with giant unbroken tokens does not crash', () => {
+    test('select-all-like page text with giant unbroken tokens does not crash', async () => {
         const blob = [
             Array(50).fill('חדשות').join(' '),
             'https://www.ynet.co.il/home/0,7340,L-8,00.html',
@@ -123,38 +123,60 @@ describe('end-to-end with the real model', () => {
             'כותרת ראשית: דבר מה קרה היום בבוקר.',
             'עוד פסקה עם טקסט עברי רגיל שאמור לקבל ניקוד תקין.',
         ].join(' ');
-        const out = diacritize(tf, model, blob);
+        const out = await diacritize(tf, model, blob);
         // Structure is preserved: stripping the added niqqud returns the input.
         assert.equal(remove_niqqud(out), remove_niqqud(blob));
     });
 
-    test('large multi-batch input (forces predict batching)', () => {
+    test('large multi-batch input (forces predict batching)', async () => {
         const blob = Array(200).fill('הם חלק ממאמצי האגודה הלאומית לשמירת הטבע בישראל').join(' ');
-        const out = diacritize(tf, model, blob);
+        const out = await diacritize(tf, model, blob);
         assert.equal(remove_niqqud(out), blob);
     });
 
-    test('characters are preserved exactly, including newlines and tabs', () => {
+    test('characters are preserved exactly, including newlines and tabs', async () => {
         const text = 'שורה ראשונה\nשורה שנייה\tסוף';
-        const out = diacritize(tf, model, text);
+        const out = await diacritize(tf, model, text);
         assert.equal(remove_niqqud(out), text);
     });
 
-    test('diacritize_batch matches per-segment diacritize', () => {
+    test('diacritize_batch matches per-segment diacritize', async () => {
         const texts = [
             'הם חלק ממאמצי האגודה הלאומית',
             'כותרת ראשית: דבר מה קרה היום.',
             'עוד פסקה עם טקסט עברי רגיל.',
         ];
-        const batched = diacritize_batch(tf, model, texts);
-        const separate = texts.map(t => diacritize(tf, model, t));
+        const batched = await diacritize_batch(tf, model, texts);
+        const separate = [];
+        for (const t of texts)
+            separate.push(await diacritize(tf, model, t));
         assert.deepEqual(batched, separate);
     });
 
-    test('no tensor leaks across calls', () => {
-        diacritize(tf, model, 'בדיקת זיכרון ראשונה');
+    test('no tensor leaks across calls', async () => {
+        await diacritize(tf, model, 'בדיקת זיכרון ראשונה');
         const before = tf.memory().numTensors;
-        diacritize_batch(tf, model, ['בדיקת זיכרון שנייה', 'ועוד אחת']);
+        await diacritize_batch(tf, model, ['בדיקת זיכרון שנייה', 'ועוד אחת']);
         assert.equal(tf.memory().numTensors, before);
+    });
+    test('rows without Hebrew are skipped: Latin-only text is returned unchanged', async () => {
+        const latin = ('lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(50)).trim();
+        const t0 = performance.now();
+        const out = await diacritize(tf, model, latin);
+        const ms = performance.now() - t0;
+        assert.equal(out, latin);
+        console.log(`# latin-only blob (${latin.length} chars): ${ms.toFixed(0)}ms`);
+    });
+
+    test('Hebrew embedded in a mostly-Latin page still gets niqqud', async () => {
+        const blob = 'lorem ipsum dolor sit amet. '.repeat(100) +
+            'הם חלק ממאמצי האגודה הלאומית ' +
+            'consectetur adipiscing elit. '.repeat(100);
+        const t0 = performance.now();
+        const out = await diacritize(tf, model, blob);
+        const ms = performance.now() - t0;
+        assert.equal(remove_niqqud(out), blob);
+        assert.ok(/[\u05B0-\u05BC]/.test(out), 'the Hebrew part should still receive niqqud');
+        console.log(`# mostly-latin blob (${blob.length} chars): ${ms.toFixed(0)}ms`);
     });
 });

--- a/text_encoding.mjs
+++ b/text_encoding.mjs
@@ -82,18 +82,48 @@ function encode_text(text) {
     return {undotted, rows};
 }
 
+// Only rows containing a Hebrew letter can receive marks; the rest of a
+// select-all-sized input (nav chrome, URLs, Latin text) is skipped entirely.
+const HEBREW_TOKEN_MIN = ALL_TOKENS.indexOf(HEBREW_LETTERS[0]);
+
+// Upper bound on rows per predict call, so one giant segment doesn't hold
+// the whole intermediate activation set alive at once.
+const ROWS_PER_PREDICT = 512;
+
 // Run the model over encoded rows and return per-token argmax classes for
 // the three heads as plain typed arrays (length rows.length * MAXLEN each).
-function run_model(tf, model, rows) {
-    return tf.tidy(() => {
-        const input = tf.tensor2d(rows, [rows.length, MAXLEN], 'float32');
-        const [niqqud, dagesh, sin] = model.predict(input, {batchSize: 64});
-        return {
-            niqqud: niqqud.argMax(-1).dataSync(),
-            dagesh: dagesh.argMax(-1).dataSync(),
-            sin: sin.argMax(-1).dataSync(),
-        };
-    });
+// Rows without Hebrew keep class 0 (no marks) and are never predicted.
+async function run_model(tf, model, rows) {
+    const heads = {
+        niqqud: new Int32Array(rows.length * MAXLEN),
+        dagesh: new Int32Array(rows.length * MAXLEN),
+        sin: new Int32Array(rows.length * MAXLEN),
+    };
+
+    const kept = [];
+    for (let i = 0; i < rows.length; i++)
+        if (rows[i].some(t => t >= HEBREW_TOKEN_MIN))
+            kept.push(i);
+
+    for (let start = 0; start < kept.length; start += ROWS_PER_PREDICT) {
+        const indices = kept.slice(start, start + ROWS_PER_PREDICT);
+        const argmaxes = tf.tidy(() => {
+            const input = tf.tensor2d(indices.map(i => rows[i]), [indices.length, MAXLEN], 'float32');
+            const [niqqud, dagesh, sin] = model.predict(input, {batchSize: 64});
+            return [niqqud.argMax(-1), dagesh.argMax(-1), sin.argMax(-1)];
+        });
+        // async readback: no dataSync() stall on the GPU pipeline
+        const [niqqud, dagesh, sin] = await Promise.all(argmaxes.map(t => t.data()));
+        argmaxes.forEach(t => t.dispose());
+        for (let j = 0; j < indices.length; j++) {
+            const dst = indices[j] * MAXLEN;
+            const src = j * MAXLEN;
+            heads.niqqud.set(niqqud.subarray(src, src + MAXLEN), dst);
+            heads.dagesh.set(dagesh.subarray(src, src + MAXLEN), dst);
+            heads.sin.set(sin.subarray(src, src + MAXLEN), dst);
+        }
+    }
+    return heads;
 }
 
 // Turn one segment's slice of the model output back into dotted text.
@@ -129,25 +159,25 @@ function decode(flat_input, heads, undotted_text, offset) {
     return output;
 }
 
-// Diacritize several independent text segments with a single model.predict
-// call. Returns one dotted string per input segment, in order.
-function diacritize_batch(tf, model, texts) {
+// Diacritize several independent text segments, batching their rows into
+// shared predict calls. Returns one dotted string per input segment, in order.
+async function diacritize_batch(tf, model, texts) {
     const encoded = texts.map(encode_text);
     const allRows = encoded.flatMap(e => e.rows);
-    const heads = run_model(tf, model, allRows);
+    const heads = await run_model(tf, model, allRows);
 
     const out = [];
     let offset = 0;
     for (const e of encoded) {
-        const flat = [].concat(...e.rows);
+        const flat = e.rows.flat();
         out.push(decode(flat, heads, e.undotted, offset));
         offset += flat.length;
     }
     return out;
 }
 
-function diacritize(tf, model, text) {
-    return diacritize_batch(tf, model, [text])[0];
+async function diacritize(tf, model, text) {
+    return (await diacritize_batch(tf, model, [text]))[0];
 }
 
 export {


### PR DESCRIPTION
Stacked on #18.

- **Skip rows without Hebrew letters** — they can't receive marks, so they never reach `model.predict` (their heads default to class 0 = no marks). This is the big one for Ctrl+A: measured on the CPU backend, a Latin-only 2.8KB blob went from a full model run to **2ms**, and a 5.7KB mostly-Latin page (one Hebrew sentence inside) runs in **<1s**.
- **Async readback**: `await data()` replaces three synchronous `arraySync()` GPU stalls; `diacritize`/`diacritize_batch` are now async.
- **Capped predict size**: at most 512 rows per predict call, scattered into preallocated result arrays — a single giant text node no longer holds the entire activation set alive.
- **Warm-up**: the service worker runs a one-letter diacritize after model load so the first click doesn't pay shader/kernel compilation.

Tests: 32 pass — new Latin-only-unchanged and Hebrew-inside-Latin-page correctness tests (with timing logs), plus the existing batch-consistency, newline round-trip and tensor-leak checks against the real model. Build green.