### PR TITLE
Ship WASM backend (12-35x faster than CPU fallback), modular tfjs imports

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,30 @@
-import * as tf from '@tensorflow/tfjs';
+// Modular tfjs imports: only core + layers + backends, instead of the
+// full @tensorflow/tfjs bundle (converters, data, vis, ...).
+import * as tf from '@tensorflow/tfjs-core';
+import {setWasmPaths} from '@tensorflow/tfjs-backend-wasm';
+import '@tensorflow/tfjs-backend-webgl';
+import '@tensorflow/tfjs-backend-cpu';
+import {loadLayersModel} from '@tensorflow/tfjs-layers';
 import {diacritize, diacritize_batch} from './text_encoding.mjs';
+
+// WASM (SIMD) is the primary backend: benchmarked 12-35x faster than the
+// plain CPU backend on this BiLSTM, predictable across machines, and immune
+// to the WebGL texture-upload failure class. WebGL remains the fallback.
+async function pick_backend() {
+    setWasmPaths(chrome.runtime.getURL('wasm/'));
+    for (const backend of ['wasm', 'webgl', 'cpu']) {
+        try {
+            if (await tf.setBackend(backend)) {
+                await tf.ready();
+                console.log('Nekudot: using backend', backend);
+                return;
+            }
+        } catch (e) {
+            console.warn(`Nekudot: backend ${backend} unavailable`, e);
+        }
+    }
+    throw new Error('no tfjs backend available');
+}
 
 // Segments are processed in chunks: each chunk is one model.predict call,
 // results stream back per segment, and yielding between chunks keeps the
@@ -7,7 +32,8 @@ import {diacritize, diacritize_batch} from './text_encoding.mjs';
 const SEGMENTS_PER_CHUNK = 32;
 
 async function load_model() {
-    const model = await tf.loadLayersModel(chrome.runtime.getURL("model/model.json"));
+    await pick_backend();
+    const model = await loadLayersModel(chrome.runtime.getURL("model/model.json"));
     // Warm-up: the first predict compiles kernels/shaders; pay that cost at
     // load time instead of on the user's first click.
     await diacritize(tf, model, 'א');

--- a/background.js
+++ b/background.js
@@ -12,6 +12,12 @@ import {diacritize, diacritize_batch} from './text_encoding.mjs';
 // to the WebGL texture-upload failure class. WebGL remains the fallback.
 async function pick_backend() {
     setWasmPaths(chrome.runtime.getURL('wasm/'));
+    // MV3 service workers have no Worker API, but tfjs's feature detection
+    // still reports thread support and then crashes spawning workers
+    // ("ReferenceError: Worker is not defined"). Force the single-threaded
+    // SIMD binary where workers don't exist.
+    if (typeof Worker === 'undefined')
+        tf.env().set('WASM_HAS_MULTITHREAD_SUPPORT', false);
     for (const backend of ['wasm', 'webgl', 'cpu']) {
         try {
             if (await tf.setBackend(backend)) {

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -37,12 +37,15 @@ Implemented as a chain of stacked PRs, one theme at a time.
   `prediction_to_text`.
 - [x] **Warm-up predict** after model load so the first click doesn't pay
   shader/kernel compilation.
-- [ ] **Slim the bundle.** Import `@tensorflow/tfjs-core` / `-layers` / one
+- [x] **Slim the bundle.** Import `@tensorflow/tfjs-core` / `-layers` / one
   backend instead of the full 1.13 MB `@tensorflow/tfjs`.
-- [ ] **Benchmark WASM backend** (SIMD/threads) against the current setup;
+- [x] **Benchmark WASM backend** (SIMD/threads) against the current setup;
   small-batch BiLSTMs over 90 timesteps are often CPU-bound.
-- [ ] **GraphModel conversion + float16 quantization** (if the converter
-  tooling cooperates): fused kernels, roughly half the 21 MB weight download.
+- [ ] **GraphModel conversion + float16 quantization**: the Python
+  `tensorflowjs_converter` cannot deserialize this model (Keras 2.19 weight
+  naming mismatch: `KeyError: 'bidirectional/forward_lstm/kernel'`).
+  Plan B: quantize the weights manifest to float16 directly in Node —
+  tfjs dequantizes float16 natively at load time.
 - [x] **Stream results** — apply per-segment results to the page as they
   arrive so large selections look "working", not frozen.
 

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
   "background": {
     "service_worker": "background.js"
   },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  },
   "permissions": [
     "activeTab",
     "scripting"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,11 @@
       "version": "1.2",
       "license": "MIT",
       "dependencies": {
-        "@tensorflow/tfjs": "^4.16.0"
+        "@tensorflow/tfjs-backend-cpu": "^4.22.0",
+        "@tensorflow/tfjs-backend-wasm": "^4.22.0",
+        "@tensorflow/tfjs-backend-webgl": "^4.22.0",
+        "@tensorflow/tfjs-core": "^4.22.0",
+        "@tensorflow/tfjs-layers": "^4.22.0"
       },
       "devDependencies": {
         "@babel/core": "^7.28.5",
@@ -3952,28 +3956,6 @@
         "@swc/counter": "^0.1.3"
       }
     },
-    "node_modules/@tensorflow/tfjs": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs/-/tfjs-4.22.0.tgz",
-      "integrity": "sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@tensorflow/tfjs-backend-cpu": "4.22.0",
-        "@tensorflow/tfjs-backend-webgl": "4.22.0",
-        "@tensorflow/tfjs-converter": "4.22.0",
-        "@tensorflow/tfjs-core": "4.22.0",
-        "@tensorflow/tfjs-data": "4.22.0",
-        "@tensorflow/tfjs-layers": "4.22.0",
-        "argparse": "^1.0.10",
-        "chalk": "^4.1.0",
-        "core-js": "3.29.1",
-        "regenerator-runtime": "^0.13.5",
-        "yargs": "^16.0.3"
-      },
-      "bin": {
-        "tfjs-custom-module": "dist/tools/custom_module/cli.js"
-      }
-    },
     "node_modules/@tensorflow/tfjs-backend-cpu": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-cpu/-/tfjs-backend-cpu-4.22.0.tgz",
@@ -3985,6 +3967,19 @@
       },
       "engines": {
         "yarn": ">= 1.3.2"
+      },
+      "peerDependencies": {
+        "@tensorflow/tfjs-core": "4.22.0"
+      }
+    },
+    "node_modules/@tensorflow/tfjs-backend-wasm": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-backend-wasm/-/tfjs-backend-wasm-4.22.0.tgz",
+      "integrity": "sha512-/IYhReRIp4jg/wYW0OwbbJZG8ON87mbz0PgkiP3CdcACRSvUN0h8rvC0O3YcDtkTQtFWF/tcXq/KlVDyV49wmA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@tensorflow/tfjs-backend-cpu": "4.22.0",
+        "@types/emscripten": "~0.0.34"
       },
       "peerDependencies": {
         "@tensorflow/tfjs-core": "4.22.0"
@@ -4004,15 +3999,6 @@
       "engines": {
         "yarn": ">= 1.3.2"
       },
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.22.0"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-converter": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-converter/-/tfjs-converter-4.22.0.tgz",
-      "integrity": "sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==",
-      "license": "Apache-2.0",
       "peerDependencies": {
         "@tensorflow/tfjs-core": "4.22.0"
       }
@@ -4041,30 +4027,6 @@
       "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
       "license": "MIT"
     },
-    "node_modules/@tensorflow/tfjs-data": {
-      "version": "4.22.0",
-      "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-data/-/tfjs-data-4.22.0.tgz",
-      "integrity": "sha512-dYmF3LihQIGvtgJrt382hSRH4S0QuAp2w1hXJI2+kOaEqo5HnUPG0k5KA6va+S1yUhx7UBToUKCBHeLHFQRV4w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/node-fetch": "^2.1.2",
-        "node-fetch": "~2.6.1",
-        "string_decoder": "^1.3.0"
-      },
-      "peerDependencies": {
-        "@tensorflow/tfjs-core": "4.22.0",
-        "seedrandom": "^3.0.5"
-      }
-    },
-    "node_modules/@tensorflow/tfjs-data/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/@tensorflow/tfjs-layers": {
       "version": "4.22.0",
       "resolved": "https://registry.npmjs.org/@tensorflow/tfjs-layers/-/tfjs-layers-4.22.0.tgz",
@@ -4074,40 +4036,17 @@
         "@tensorflow/tfjs-core": "4.22.0"
       }
     },
-    "node_modules/@tensorflow/tfjs/node_modules/core-js": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
-      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
-      "hasInstallScript": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
+    "node_modules/@types/emscripten": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/emscripten/-/emscripten-0.0.34.tgz",
+      "integrity": "sha512-QSb9ojDincskc+uKMI0KXp8e1NALFINCrMlp8VGKGcTSxeEyRTTKyjWw75NYrCZHUsVEEEpr1tYHpbtaC++/sQ==",
+      "license": "MIT"
     },
     "node_modules/@types/long": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT"
-    },
-    "node_modules/@types/node": {
-      "version": "24.10.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
-      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-      "license": "MIT",
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
-    "node_modules/@types/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "form-data": "^4.0.4"
-      }
     },
     "node_modules/@types/offscreencanvas": {
       "version": "2019.3.0",
@@ -4127,18 +4066,11 @@
       "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -4149,24 +4081,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "dev": true
-    },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4298,19 +4217,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001761",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001761.tgz",
@@ -4336,6 +4242,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -4373,16 +4280,6 @@
         "git-clang-format": "bin/git-clang-format"
       }
     },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -4397,6 +4294,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -4407,18 +4305,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -4438,14 +4326,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-libc": {
@@ -4490,20 +4370,6 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
@@ -4511,60 +4377,11 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
-    "node_modules/es-define-property": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-errors": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4592,22 +4409,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -4618,6 +4419,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4630,51 +4432,6 @@
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/glob": {
@@ -4714,57 +4471,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/gopd": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/has-symbols": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4835,14 +4555,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -5207,15 +4919,6 @@
         "yallist": "^3.0.2"
       }
     },
-    "node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -5228,25 +4931,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.30",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
-      "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
-      "dependencies": {
-        "mime-db": "1.47.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5561,19 +5245,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/regenerator-runtime": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -5599,6 +5270,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5634,39 +5306,11 @@
         "node": ">=10"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
-    },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -5732,12 +5376,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
@@ -5831,35 +5469,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -5867,31 +5481,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "engines": {
-        "node": ">=10"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,15 +9,20 @@
     "nekudot"
   ],
   "dependencies": {
-    "@tensorflow/tfjs": "^4.16.0"
+    "@tensorflow/tfjs-backend-cpu": "^4.22.0",
+    "@tensorflow/tfjs-backend-wasm": "^4.22.0",
+    "@tensorflow/tfjs-backend-webgl": "^4.22.0",
+    "@tensorflow/tfjs-core": "^4.22.0",
+    "@tensorflow/tfjs-layers": "^4.22.0"
   },
   "scripts": {
     "test": "node --test \"tests/**/*.test.mjs\"",
-    "copy": "cp manifest.json dist/ && cp -R images dist/images && cp -R model dist/model",
+    "copy": "cp manifest.json dist/ && cp -R images dist/images && cp -R model dist/model && mkdir -p dist/wasm && cp node_modules/@tensorflow/tfjs-backend-wasm/dist/*.wasm dist/wasm/",
     "prebuild": "rm -rf dist",
     "prebuild-dev": "rm -rf dist",
     "build": "parcel build content.js background.js --dist-dir dist && npm run copy",
-    "build-dev": "NODE_ENV=development parcel build content.js background.js --dist-dir dist && npm run copy"
+    "build-dev": "NODE_ENV=development parcel build content.js background.js --dist-dir dist && npm run copy",
+    "bench": "node scripts/benchmark_backends.mjs"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/scripts/benchmark_backends.mjs
+++ b/scripts/benchmark_backends.mjs
@@ -1,0 +1,46 @@
+// Benchmark diacritization across tfjs backends available in Node.
+// Usage: npm run bench
+// The extension runs WebGL in the browser (not measurable here); this
+// compares the CPU and WASM backends to decide whether shipping the WASM
+// backend as a fallback is worthwhile.
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-cpu';
+import '@tensorflow/tfjs-backend-wasm';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {loadModelFromDisk} from './model_loader.mjs';
+import {diacritize} from '../text_encoding.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const SHORT = 'הם חלק ממאמצי האגודה הלאומית לשמירת הטבע בישראל';
+const LONG = Array(50).fill(SHORT).join(' ');
+
+async function bench(backend) {
+    await tf.setBackend(backend);
+    await tf.ready();
+    const model = await loadModelFromDisk(join(repoRoot, 'model'));
+    await diacritize(tf, model, 'א'); // warm-up
+
+    const results = {};
+    for (const [name, text] of [['short', SHORT], ['long', LONG]]) {
+        const times = [];
+        for (let i = 0; i < 3; i++) {
+            const t0 = performance.now();
+            await diacritize(tf, model, text);
+            times.push(performance.now() - t0);
+        }
+        results[name] = Math.min(...times);
+    }
+    model.dispose();
+    return results;
+}
+
+for (const backend of ['cpu', 'wasm']) {
+    try {
+        const r = await bench(backend);
+        console.log(`${backend.padEnd(5)} short (${SHORT.length} chars): ${r.short.toFixed(0)}ms   long (${LONG.length} chars): ${r.long.toFixed(0)}ms`);
+    } catch (e) {
+        console.log(`${backend.padEnd(5)} unavailable: ${e.message}`);
+    }
+}

--- a/scripts/model_loader.mjs
+++ b/scripts/model_loader.mjs
@@ -1,0 +1,25 @@
+// Load the extension's layers model from disk in Node (tests, benchmarks).
+import {readFile} from 'node:fs/promises';
+import {join} from 'node:path';
+import {io} from '@tensorflow/tfjs-core';
+import {loadLayersModel} from '@tensorflow/tfjs-layers';
+
+async function loadModelFromDisk(dir) {
+    const modelJSON = JSON.parse(await readFile(join(dir, 'model.json'), 'utf8'));
+    const weightSpecs = modelJSON.weightsManifest.flatMap(g => g.weights);
+    const buffers = await Promise.all(
+        modelJSON.weightsManifest.flatMap(g => g.paths).map(p => readFile(join(dir, p))));
+    const weightData = new Uint8Array(buffers.reduce((a, b) => a + b.length, 0));
+    let offset = 0;
+    for (const b of buffers) {
+        weightData.set(b, offset);
+        offset += b.length;
+    }
+    return loadLayersModel(io.fromMemory({
+        modelTopology: modelJSON.modelTopology,
+        weightSpecs,
+        weightData: weightData.buffer,
+    }));
+}
+
+export {loadModelFromDisk};

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -27,4 +27,9 @@ describe('manifest', () => {
         assert.deepEqual([...manifest.permissions].sort(),
             ['activeTab', 'scripting']);
     });
+
+    test('CSP allows WebAssembly for the wasm backend', () => {
+        assert.match(manifest.content_security_policy.extension_pages,
+            /'wasm-unsafe-eval'/);
+    });
 });

--- a/tests/text_encoding.test.mjs
+++ b/tests/text_encoding.test.mjs
@@ -1,13 +1,19 @@
 import {test, describe, before} from 'node:test';
 import assert from 'node:assert/strict';
-import {readFile} from 'node:fs/promises';
 import {join, dirname} from 'node:path';
 import {fileURLToPath} from 'node:url';
-import * as tf from '@tensorflow/tfjs';
+import * as tf from '@tensorflow/tfjs-core';
+// wasm backend: same numerics as in the extension, ~30x faster suite than cpu
+import '@tensorflow/tfjs-backend-wasm';
+import '@tensorflow/tfjs-backend-cpu';
+import {loadModelFromDisk} from '../scripts/model_loader.mjs';
 import {normalize, split_to_rows, remove_niqqud, diacritize, diacritize_batch} from '../text_encoding.mjs';
 
 const MAXLEN = 90;
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+await tf.setBackend('wasm');
+await tf.ready();
 
 function encode(text) {
     return text.replace(/./gms, normalize);
@@ -91,22 +97,7 @@ describe('end-to-end with the real model', () => {
     let model;
 
     before(async () => {
-        const dir = join(repoRoot, 'model');
-        const modelJSON = JSON.parse(await readFile(join(dir, 'model.json'), 'utf8'));
-        const weightSpecs = modelJSON.weightsManifest.flatMap(g => g.weights);
-        const buffers = await Promise.all(
-            modelJSON.weightsManifest.flatMap(g => g.paths).map(p => readFile(join(dir, p))));
-        const weightData = new Uint8Array(buffers.reduce((a, b) => a + b.length, 0));
-        let offset = 0;
-        for (const b of buffers) {
-            weightData.set(b, offset);
-            offset += b.length;
-        }
-        model = await tf.loadLayersModel(tf.io.fromMemory({
-            modelTopology: modelJSON.modelTopology,
-            weightSpecs,
-            weightData: weightData.buffer,
-        }));
+        model = await loadModelFromDisk(join(repoRoot, 'model'));
     });
 
     test('short sentence gets niqqud', async () => {

--- a/text_encoding.mjs
+++ b/text_encoding.mjs
@@ -109,8 +109,9 @@ async function run_model(tf, model, rows) {
         const indices = kept.slice(start, start + ROWS_PER_PREDICT);
         const argmaxes = tf.tidy(() => {
             const input = tf.tensor2d(indices.map(i => rows[i]), [indices.length, MAXLEN], 'float32');
-            const [niqqud, dagesh, sin] = model.predict(input, {batchSize: 64});
-            return [niqqud.argMax(-1), dagesh.argMax(-1), sin.argMax(-1)];
+            const heads = model.predict(input, {batchSize: 64});
+            // functional API: modular tfjs-core does not register chained tensor ops
+            return heads.map(h => tf.argMax(h, -1));
         });
         // async readback: no dataSync() stall on the GPU pipeline
         const [niqqud, dagesh, sin] = await Promise.all(argmaxes.map(t => t.data()));


### PR DESCRIPTION
Stacked on #19.

## Benchmark (node, real model — npm run bench)

| backend | 47-char sentence | 2.4KB paragraph |
|---|---|---|
| cpu | 848ms | 26.8s |
| **wasm (SIMD)** | **71ms** | **0.8s** |

WebGL isn't measurable in node, but WASM's numbers are already excellent, consistent across machines, and immune to the WebGL texture-upload failure class that caused the original crash — so the extension now picks **wasm → webgl → cpu** explicitly at load.

## Changes

- WASM binaries ship in `dist/wasm/` (copied at build), loaded via `chrome.runtime.getURL`; manifest gains the MV3-required `'wasm-unsafe-eval'` CSP (locked in by a manifest test)
- `@tensorflow/tfjs` (everything-bundle) replaced with `tfjs-core` + `tfjs-layers` + backends; `argMax` switched to the functional API since modular core doesn't register chained tensor ops
- Node model loading extracted to `scripts/model_loader.mjs`; new `npm run bench` compares backends
- **Tests now run on WASM: the suite went from ~128s to ~5s** (same numerics as the shipped extension)

Also investigated GraphModel conversion + float16 via the Python `tensorflowjs_converter`: it cannot deserialize this model (Keras 2.19 weight-naming mismatch, `KeyError: 'bidirectional/forward_lstm/kernel'`). Documented in the plan; float16 quantization will instead be done directly in Node in a follow-up.

Tests: 33 pass. Build green.