### PR TITLE
Float16 model quantization at build time: extension 35MB -> 12MB

### DIFF
--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -41,7 +41,7 @@ Implemented as a chain of stacked PRs, one theme at a time.
   backend instead of the full 1.13 MB `@tensorflow/tfjs`.
 - [x] **Benchmark WASM backend** (SIMD/threads) against the current setup;
   small-batch BiLSTMs over 90 timesteps are often CPU-bound.
-- [ ] **GraphModel conversion + float16 quantization**: the Python
+- [x] **GraphModel conversion + float16 quantization**: the Python
   `tensorflowjs_converter` cannot deserialize this model (Keras 2.19 weight
   naming mismatch: `KeyError: 'bidirectional/forward_lstm/kernel'`).
   Plan B: quantize the weights manifest to float16 directly in Node —

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "scripts": {
     "test": "node --test \"tests/**/*.test.mjs\"",
-    "copy": "cp manifest.json dist/ && cp -R images dist/images && cp -R model dist/model && mkdir -p dist/wasm && cp node_modules/@tensorflow/tfjs-backend-wasm/dist/*.wasm dist/wasm/",
+    "copy": "cp manifest.json dist/ && cp -R images dist/images && node scripts/quantize_model.mjs model dist/model && mkdir -p dist/wasm && cp node_modules/@tensorflow/tfjs-backend-wasm/dist/*.wasm dist/wasm/",
     "prebuild": "rm -rf dist",
     "prebuild-dev": "rm -rf dist",
-    "build": "parcel build content.js background.js --dist-dir dist && npm run copy",
+    "build": "parcel build content.js background.js --no-source-maps --dist-dir dist && npm run copy",
     "build-dev": "NODE_ENV=development parcel build content.js background.js --dist-dir dist && npm run copy",
     "bench": "node scripts/benchmark_backends.mjs"
   },

--- a/scripts/quantize_model.mjs
+++ b/scripts/quantize_model.mjs
@@ -1,0 +1,121 @@
+// Quantize a tfjs layers model's float32 weights to float16 (half size).
+// tfjs dequantizes `quantization: {dtype: 'float16'}` natively at load time.
+//
+// Used at build time (see the `copy` npm script) so model/ stays the
+// float32 source of truth; the extension ships the quantized copy.
+//
+// CLI: node scripts/quantize_model.mjs <srcDir> <dstDir>
+import {readFile, writeFile, mkdir} from 'node:fs/promises';
+import {join} from 'node:path';
+
+const f32buf = new Float32Array(1);
+const u32buf = new Uint32Array(f32buf.buffer);
+
+// IEEE 754 float32 -> float16 bits, round-to-nearest-even.
+function toHalf(value) {
+    f32buf[0] = value;
+    const x = u32buf[0];
+    const sign = (x >>> 16) & 0x8000;
+    const exp = (x >>> 23) & 0xff;
+    const frac = x & 0x7fffff;
+
+    if (exp === 0xff) // Inf / NaN
+        return sign | 0x7c00 | (frac ? 0x200 : 0);
+
+    const e = exp - 127 + 15;
+    if (e >= 0x1f) // overflow -> Inf
+        return sign | 0x7c00;
+
+    if (e <= 0) { // subnormal half (or underflow to zero)
+        if (e < -10)
+            return sign;
+        const m = (frac | 0x800000) >>> (1 - e);
+        return sign | ((m >>> 13) + roundHalfEven(m, 13));
+    }
+
+    // mantissa rounding may carry into the exponent bits — that is the
+    // correct rounded result (and saturates to Inf at e === 0x1f)
+    return (sign | (e << 10) | (frac >>> 13)) + roundHalfEven(frac, 13);
+}
+
+// Rounding increment for dropping `bits` low bits of `m`, nearest-even.
+function roundHalfEven(m, bits) {
+    const lsb = (m >>> bits) & 1;
+    const roundBit = (m >>> (bits - 1)) & 1;
+    const sticky = m & ((1 << (bits - 1)) - 1);
+    return (roundBit && (sticky || lsb)) ? 1 : 0;
+}
+
+// Quantize in-memory model artifacts. Returns new {modelJSON, weightData}.
+function quantizeToFloat16(modelJSON, weightData) {
+    const bytes = new Uint8Array(weightData);
+    const specs = modelJSON.weightsManifest.flatMap(g => g.weights);
+
+    const parts = [];
+    const newSpecs = [];
+    let offset = 0;
+    let outBytes = 0;
+    for (const spec of specs) {
+        const size = spec.shape.reduce((a, b) => a * b, 1);
+        if (spec.dtype === 'float32') {
+            const src = new Float32Array(size);
+            new Uint8Array(src.buffer).set(bytes.subarray(offset, offset + size * 4));
+            const dst = new Uint16Array(size);
+            for (let i = 0; i < size; i++)
+                dst[i] = toHalf(src[i]);
+            parts.push(new Uint8Array(dst.buffer));
+            newSpecs.push({...spec, quantization: {dtype: 'float16'}});
+            offset += size * 4;
+            outBytes += size * 2;
+        } else {
+            const byteLength = size * {int32: 4, uint8: 1, bool: 1}[spec.dtype];
+            parts.push(bytes.subarray(offset, offset + byteLength));
+            newSpecs.push(spec);
+            offset += byteLength;
+            outBytes += byteLength;
+        }
+    }
+
+    const out = new Uint8Array(outBytes);
+    let outOffset = 0;
+    for (const part of parts) {
+        out.set(part, outOffset);
+        outOffset += part.length;
+    }
+
+    const newModelJSON = {
+        ...modelJSON,
+        weightsManifest: [{paths: ['group1-shard1of1.bin'], weights: newSpecs}],
+    };
+    return {modelJSON: newModelJSON, weightData: out.buffer};
+}
+
+async function readModelArtifacts(dir) {
+    const modelJSON = JSON.parse(await readFile(join(dir, 'model.json'), 'utf8'));
+    const buffers = await Promise.all(
+        modelJSON.weightsManifest.flatMap(g => g.paths).map(p => readFile(join(dir, p))));
+    const weightData = new Uint8Array(buffers.reduce((a, b) => a + b.length, 0));
+    let offset = 0;
+    for (const b of buffers) {
+        weightData.set(b, offset);
+        offset += b.length;
+    }
+    return {modelJSON, weightData: weightData.buffer};
+}
+
+export {toHalf, quantizeToFloat16, readModelArtifacts};
+
+// CLI
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split('/').pop())) {
+    const [srcDir, dstDir] = process.argv.slice(2);
+    if (!srcDir || !dstDir) {
+        console.error('usage: node scripts/quantize_model.mjs <srcDir> <dstDir>');
+        process.exit(1);
+    }
+    const src = await readModelArtifacts(srcDir);
+    const {modelJSON, weightData} = quantizeToFloat16(src.modelJSON, src.weightData);
+    await mkdir(dstDir, {recursive: true});
+    await writeFile(join(dstDir, 'model.json'), JSON.stringify(modelJSON));
+    await writeFile(join(dstDir, 'group1-shard1of1.bin'), Buffer.from(weightData));
+    console.log(`quantized ${srcDir} (${src.weightData.byteLength} B) -> ${dstDir} (${weightData.byteLength} B)`);
+}

--- a/tests/quantize_model.test.mjs
+++ b/tests/quantize_model.test.mjs
@@ -1,0 +1,117 @@
+import {test, describe, before} from 'node:test';
+import assert from 'node:assert/strict';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
+import * as tf from '@tensorflow/tfjs-core';
+import '@tensorflow/tfjs-backend-wasm';
+import {io} from '@tensorflow/tfjs-core';
+import {loadLayersModel} from '@tensorflow/tfjs-layers';
+import {toHalf, quantizeToFloat16, readModelArtifacts} from '../scripts/quantize_model.mjs';
+import {loadModelFromDisk} from '../scripts/model_loader.mjs';
+import {diacritize, remove_niqqud} from '../text_encoding.mjs';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+await tf.setBackend('wasm');
+await tf.ready();
+
+// Reference float16 round-trip via DataView-free bit math.
+function halfToFloat(h) {
+    const sign = (h & 0x8000) ? -1 : 1;
+    const exp = (h >>> 10) & 0x1f;
+    const frac = h & 0x3ff;
+    if (exp === 0) return sign * frac * 2 ** -24;
+    if (exp === 0x1f) return frac ? NaN : sign * Infinity;
+    return sign * (1 + frac / 1024) * 2 ** (exp - 15);
+}
+
+describe('toHalf', () => {
+    test('exact values round-trip', () => {
+        for (const v of [0, 1, -1, 0.5, -0.5, 2, 1024, -1024, 0.25, 65504]) {
+            assert.equal(halfToFloat(toHalf(v)), v, `value ${v}`);
+        }
+    });
+
+    test('signed zero and infinities', () => {
+        assert.equal(toHalf(0), 0x0000);
+        assert.equal(toHalf(-0), 0x8000);
+        assert.equal(toHalf(Infinity), 0x7c00);
+        assert.equal(toHalf(-Infinity), 0xfc00);
+        assert.ok(Number.isNaN(halfToFloat(toHalf(NaN))));
+    });
+
+    test('overflow saturates to infinity, underflow to zero', () => {
+        assert.equal(halfToFloat(toHalf(1e6)), Infinity);
+        assert.equal(halfToFloat(toHalf(-1e6)), -Infinity);
+        assert.equal(halfToFloat(toHalf(1e-10)), 0);
+    });
+
+    test('round-trip error is within half precision (relative 2^-11)', () => {
+        let x = 0x12345678;
+        for (let i = 0; i < 10000; i++) {
+            // deterministic LCG so the test is reproducible
+            x = (Math.imul(x, 1664525) + 1013904223) >>> 0;
+            const v = (x / 2 ** 32 - 0.5) * 8; // typical weight range
+            const err = Math.abs(halfToFloat(toHalf(v)) - v);
+            assert.ok(err <= Math.max(Math.abs(v) * 2 ** -11, 2 ** -24), `value ${v} err ${err}`);
+        }
+    });
+
+    test('rounds to nearest even', () => {
+        // 1 + 2^-11 is exactly between 1 (0x3c00) and 1 + 2^-10 (0x3c01):
+        // ties go to the even mantissa.
+        assert.equal(toHalf(1 + 2 ** -11), 0x3c00);
+        // Just above the tie rounds up.
+        assert.equal(toHalf(1 + 2 ** -11 + 2 ** -20), 0x3c01);
+    });
+});
+
+describe('quantized model', () => {
+    let f32model, f16model;
+
+    before(async () => {
+        f32model = await loadModelFromDisk(join(repoRoot, 'model'));
+        const src = await readModelArtifacts(join(repoRoot, 'model'));
+        const q = quantizeToFloat16(src.modelJSON, src.weightData);
+        const weightSpecs = q.modelJSON.weightsManifest.flatMap(g => g.weights);
+        f16model = await loadLayersModel(io.fromMemory({
+            modelTopology: q.modelJSON.modelTopology,
+            weightSpecs,
+            weightData: q.weightData,
+        }));
+    });
+
+    test('weights shrink to about half', async () => {
+        const src = await readModelArtifacts(join(repoRoot, 'model'));
+        const q = quantizeToFloat16(src.modelJSON, src.weightData);
+        const ratio = q.weightData.byteLength / src.weightData.byteLength;
+        assert.ok(ratio < 0.55, `expected ~0.5, got ${ratio.toFixed(3)}`);
+    });
+
+    test('diacritization output stays essentially identical', async () => {
+        const samples = [
+            'הם חלק ממאמצי האגודה הלאומית לשמירת הטבע בישראל',
+            'כותרת ראשית: דבר מה קרה היום בבוקר בעיר הגדולה.',
+            'הממשלה אישרה את התקציב החדש לשנת הלימודים הקרובה.',
+            'מזג האוויר צפוי להיות חם ויבש ברוב אזורי הארץ.',
+            'שחקן הכדורגל כבש שלושה שערים במשחק אמש מול היריבה.',
+            'המחקר החדש מגלה ממצאים מפתיעים על אורח החיים שלנו.',
+            'ראש העיר הודיע על תוכנית בנייה חדשה בשכונות הדרום.',
+            'בית המשפט קיבל את הערעור ופסק פיצויים לתובעים.',
+        ];
+        let same = 0, total = 0;
+        for (const text of samples) {
+            const a = await diacritize(tf, f32model, text);
+            const b = await diacritize(tf, f16model, text);
+            assert.equal(remove_niqqud(b), text, 'quantized output must round-trip');
+            const len = Math.max(a.length, b.length);
+            for (let i = 0; i < len; i++)
+                if (a[i] === b[i]) same++;
+            total += len;
+        }
+        const agreement = same / total;
+        console.log(`# f32/f16 agreement: ${(agreement * 100).toFixed(2)}%`);
+        assert.ok(agreement >= 0.99,
+            `float16 model diverges from float32: ${(agreement * 100).toFixed(2)}% agreement`);
+    });
+});


### PR DESCRIPTION
Stacked on #20.

The Python `tensorflowjs_converter` can't deserialize this model (Keras 2.19 weight-naming mismatch), so quantization happens directly in Node: `scripts/quantize_model.mjs` converts every float32 weight to float16 with IEEE round-to-nearest-even and marks the manifest with `quantization: {dtype: 'float16'}`, which tfjs dequantizes natively at load. `model/` remains the float32 source of truth; the `copy` build step writes the quantized copy into `dist/model`.

**Validation** (all in `npm test`, 40 passing):
- `toHalf` unit tests: exact round-trips, signed zero, Inf/NaN, overflow/underflow saturation, a 10k-sample relative-error bound, and tie-to-even cases
- End-to-end: the float16 model's diacritization output on 8 varied sentences is **100.00% character-identical** to float32 (asserted ≥99%), with exact text round-trip

**Sizes**: model 21.3MB → 10.6MB; also stopped shipping the 23MB `background.js.map` in production builds (`--no-source-maps`). Packaged `dist/`: 35MB → 12MB.