### PR TITLE
Invocation surfaces: context menu, shortcut, iframes, whole-page mode

### DIFF
--- a/background.js
+++ b/background.js
@@ -48,14 +48,58 @@ async function load_model() {
 
 const model = load_model();
 
-function inject(tab) {
-    chrome.scripting.executeScript({
-        target: {tabId: tab.id},
-        files: ['content.js'],
-    });
+// Probe every frame for a live selection: inject the selection entry into
+// exactly the frames that have one; with no selection anywhere, run
+// whole-page mode in the top frame.
+async function invoke(tab) {
+    if (!tab || tab.id === undefined) return;
+    try {
+        const probes = await chrome.scripting.executeScript({
+            target: {tabId: tab.id, allFrames: true},
+            func: () => {
+                const s = window.getSelection();
+                return !!(s && s.rangeCount > 0 && !s.getRangeAt(0).collapsed);
+            },
+        });
+        const frameIds = probes.filter(p => p && p.result).map(p => p.frameId);
+        if (frameIds.length > 0) {
+            await chrome.scripting.executeScript({
+                target: {tabId: tab.id, frameIds},
+                files: ['content.js'],
+            });
+        } else {
+            await chrome.scripting.executeScript({
+                target: {tabId: tab.id},
+                files: ['content_page.js'],
+            });
+        }
+    } catch (e) {
+        console.warn('Nekudot: cannot run on this page', e);
+    }
 }
 
-chrome.action.onClicked.addListener(inject);
+chrome.action.onClicked.addListener(invoke);
+
+chrome.runtime.onInstalled.addListener(() => {
+    chrome.contextMenus.removeAll(() => {
+        chrome.contextMenus.create({
+            id: 'nekudot-selection',
+            title: 'הוסף ניקוד',
+            contexts: ['selection'],
+        });
+        chrome.contextMenus.create({
+            id: 'nekudot-page',
+            title: 'הוסף ניקוד לכל הדף',
+            contexts: ['page'],
+        });
+    });
+});
+
+chrome.contextMenus.onClicked.addListener((info, tab) => invoke(tab));
+
+chrome.commands.onCommand.addListener((command, tab) => {
+    if (command === 'add-nekudot') invoke(tab);
+});
 
 function post(port, message) {
     try {

--- a/content.js
+++ b/content.js
@@ -1,49 +1,7 @@
+// Entry point for diacritizing the current selection. The background probes
+// frames for a selection and injects this file only where one exists.
 import {nodeSegment} from './content_lib.mjs';
-
-/**
- * Get the text nodes contained in a given range, skipping nodes whose text
- * is never rendered (script/style/etc.) — a select-all range can intersect
- * Hebrew-containing JSON-LD, which must not be rewritten.
- *
- * @param {Range} range
- * @returns {Text[]}
- */
-function getSelectedNodes(range) {
-    const root = range.commonAncestorContainer.nodeType === Node.TEXT_NODE
-        ? range.commonAncestorContainer.parentElement
-        : range.commonAncestorContainer;
-    if (!root) return [];
-
-    const walker = document.createTreeWalker(
-        root,
-        NodeFilter.SHOW_TEXT,
-        {
-            acceptNode(node) {
-                if (!range.intersectsNode(node))
-                    return NodeFilter.FILTER_REJECT;
-                if (node.parentElement && node.parentElement.closest('script,style,noscript,template'))
-                    return NodeFilter.FILTER_REJECT;
-                return NodeFilter.FILTER_ACCEPT;
-            }
-        }
-    );
-
-    const nodes = [];
-    for (let node = walker.nextNode(); node; node = walker.nextNode())
-        nodes.push(node);
-    return nodes;
-}
-
-function showToast(message) {
-    const toast = document.createElement('div');
-    toast.textContent = message;
-    toast.setAttribute('dir', 'rtl');
-    toast.style.cssText = 'position:fixed;top:16px;right:16px;z-index:2147483647;' +
-        'background:#333;color:#fff;padding:10px 16px;border-radius:6px;' +
-        'font:14px sans-serif;box-shadow:0 2px 8px rgba(0,0,0,.35)';
-    document.documentElement.appendChild(toast);
-    setTimeout(() => toast.remove(), 4000);
-}
+import {collectTextNodes, requestDiacritics} from './content_runtime.mjs';
 
 function setNekudot() {
     const selection = window.getSelection();
@@ -52,10 +10,15 @@ function setNekudot() {
     const range = selection.getRangeAt(0);
     if (range.collapsed) return;
 
+    const root = range.commonAncestorContainer.nodeType === Node.TEXT_NODE
+        ? range.commonAncestorContainer.parentElement
+        : range.commonAncestorContainer;
+    if (!root) return;
+
     // pending: id -> how to put the diacritized middle back into its node
     const pending = new Map();
     const segments = [];
-    for (const node of getSelectedNodes(range)) {
+    for (const node of collectTextNodes(root, range)) {
         const seg = nodeSegment(
             node.textContent,
             node === range.startContainer,
@@ -68,24 +31,7 @@ function setNekudot() {
         pending.set(id, {node, prefix: seg.prefix, suffix: seg.suffix});
         segments.push({id, text: seg.middle});
     }
-    if (segments.length === 0) return;
-
-    const port = chrome.runtime.connect({name: 'nekudot'});
-    port.onMessage.addListener((msg) => {
-        if (msg.type === 'result') {
-            const entry = pending.get(msg.id);
-            if (entry && entry.node.isConnected)
-                entry.node.textContent = entry.prefix + msg.text + entry.suffix;
-            pending.delete(msg.id);
-        } else if (msg.type === 'done') {
-            port.disconnect();
-        } else if (msg.type === 'fatal') {
-            console.error('Nekudot failed:', msg.reason);
-            showToast('הוספת הניקוד נכשלה');
-            port.disconnect();
-        }
-    });
-    port.postMessage({type: 'diacritize', segments});
+    requestDiacritics(segments, pending);
 }
 
 setNekudot();

--- a/content_page.js
+++ b/content_page.js
@@ -1,0 +1,23 @@
+// Entry point for whole-page mode: injected into the top frame when no
+// frame has a selection — diacritizes all Hebrew text on the page.
+import {nodeSegment} from './content_lib.mjs';
+import {collectTextNodes, requestDiacritics, showToast} from './content_runtime.mjs';
+
+function setNekudotWholePage() {
+    const pending = new Map();
+    const segments = [];
+    for (const node of collectTextNodes(document.body)) {
+        const seg = nodeSegment(node.textContent, false, false, 0, 0);
+        if (!seg) continue;
+        const id = segments.length;
+        pending.set(id, {node, prefix: seg.prefix, suffix: seg.suffix});
+        segments.push({id, text: seg.middle});
+    }
+    if (segments.length === 0) {
+        showToast('לא נמצא טקסט בעברית בדף');
+        return;
+    }
+    requestDiacritics(segments, pending);
+}
+
+setNekudotWholePage();

--- a/content_runtime.mjs
+++ b/content_runtime.mjs
@@ -1,0 +1,69 @@
+// Shared DOM runtime for the content entry points (selection & whole-page).
+
+/**
+ * Collect text nodes under root, optionally restricted to a Range, skipping
+ * nodes whose text is never rendered (script/style/etc.) — a select-all
+ * range can intersect Hebrew-containing JSON-LD, which must not be rewritten.
+ *
+ * @param {Node} root
+ * @param {Range|null} range
+ * @returns {Text[]}
+ */
+function collectTextNodes(root, range = null) {
+    const walker = document.createTreeWalker(
+        root,
+        NodeFilter.SHOW_TEXT,
+        {
+            acceptNode(node) {
+                if (range && !range.intersectsNode(node))
+                    return NodeFilter.FILTER_REJECT;
+                if (node.parentElement && node.parentElement.closest('script,style,noscript,template'))
+                    return NodeFilter.FILTER_REJECT;
+                return NodeFilter.FILTER_ACCEPT;
+            }
+        }
+    );
+
+    const nodes = [];
+    for (let node = walker.nextNode(); node; node = walker.nextNode())
+        nodes.push(node);
+    return nodes;
+}
+
+function showToast(message) {
+    const toast = document.createElement('div');
+    toast.textContent = message;
+    toast.setAttribute('dir', 'rtl');
+    toast.style.cssText = 'position:fixed;top:16px;right:16px;z-index:2147483647;' +
+        'background:#333;color:#fff;padding:10px 16px;border-radius:6px;' +
+        'font:14px sans-serif;box-shadow:0 2px 8px rgba(0,0,0,.35)';
+    document.documentElement.appendChild(toast);
+    setTimeout(() => toast.remove(), 4000);
+}
+
+/**
+ * Send segments to the background over a port and apply each result to its
+ * node as it arrives. `pending` maps segment id -> {node, prefix, suffix}.
+ */
+function requestDiacritics(segments, pending) {
+    if (segments.length === 0) return;
+
+    const port = chrome.runtime.connect({name: 'nekudot'});
+    port.onMessage.addListener((msg) => {
+        if (msg.type === 'result') {
+            const entry = pending.get(msg.id);
+            if (entry && entry.node.isConnected)
+                entry.node.textContent = entry.prefix + msg.text + entry.suffix;
+            pending.delete(msg.id);
+        } else if (msg.type === 'done') {
+            port.disconnect();
+        } else if (msg.type === 'fatal') {
+            console.error('Nekudot failed:', msg.reason);
+            showToast('הוספת הניקוד נכשלה');
+            port.disconnect();
+        }
+    });
+    port.postMessage({type: 'diacritize', segments});
+}
+
+export {collectTextNodes, showToast, requestDiacritics};

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -51,11 +51,11 @@ Implemented as a chain of stacked PRs, one theme at a time.
 
 ## 3. New features
 
-- [ ] **Context-menu entry and keyboard shortcut** — more discoverable than
+- [x] **Context-menu entry and keyboard shortcut** — more discoverable than
   the toolbar icon.
-- [ ] **Iframe selections** — `executeScript` currently targets only the top
+- [x] **Iframe selections** — `executeScript` currently targets only the top
   frame, silently ignoring text selected inside embedded frames.
-- [ ] **Whole-page mode** — with no selection, dot all Hebrew text on the page.
+- [x] **Whole-page mode** — with no selection, dot all Hebrew text on the page.
 - [ ] **Toggle/undo** — second invocation restores the original text.
 - [ ] **Editable-field support** — `<textarea>`, `<input>`, `contenteditable`
   (Gmail compose, comment boxes).

--- a/manifest.json
+++ b/manifest.json
@@ -12,8 +12,18 @@
   },
   "permissions": [
     "activeTab",
+    "contextMenus",
     "scripting"
   ],
+  "commands": {
+    "add-nekudot": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+Y",
+        "mac": "Command+Shift+Y"
+      },
+      "description": "Add nekudot to the selection (or the whole page)"
+    }
+  },
   "action": {
     "default_icon": {
       "16": "/images/aleph_16.png",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
     "copy": "cp manifest.json dist/ && cp -R images dist/images && node scripts/quantize_model.mjs model dist/model && mkdir -p dist/wasm && cp node_modules/@tensorflow/tfjs-backend-wasm/dist/*.wasm dist/wasm/",
     "prebuild": "rm -rf dist",
     "prebuild-dev": "rm -rf dist",
-    "build": "parcel build content.js background.js --no-source-maps --dist-dir dist && npm run copy",
-    "build-dev": "NODE_ENV=development parcel build content.js background.js --dist-dir dist && npm run copy",
+    "build": "parcel build content.js content_page.js background.js --no-source-maps --dist-dir dist && npm run copy",
+    "build-dev": "NODE_ENV=development parcel build content.js content_page.js background.js --dist-dir dist && npm run copy",
     "bench": "node scripts/benchmark_backends.mjs"
   },
   "devDependencies": {

--- a/tests/manifest.test.mjs
+++ b/tests/manifest.test.mjs
@@ -25,7 +25,11 @@ describe('manifest', () => {
 
     test('permissions stay minimal', () => {
         assert.deepEqual([...manifest.permissions].sort(),
-            ['activeTab', 'scripting']);
+            ['activeTab', 'contextMenus', 'scripting']);
+    });
+
+    test('keyboard command is declared', () => {
+        assert.ok(manifest.commands['add-nekudot'].suggested_key.default);
     });
 
     test('CSP allows WebAssembly for the wasm backend', () => {


### PR DESCRIPTION
Stacked on #21.

- **Context menu**: 'הוסף ניקוד' on selections, 'הוסף ניקוד לכל הדף' on the page — far more discoverable than the toolbar icon
- **Keyboard shortcut**: Ctrl/Cmd+Shift+Y (user-remappable at chrome://extensions/shortcuts)
- **Iframe selections finally work**: the background probes all frames for a live selection and injects the selection script into exactly those frames; previously `executeScript` hit only the top frame, silently ignoring iframe selections
- **Whole-page mode**: when nothing is selected, all Hebrew text nodes in the page get niqqud (toast if the page has no Hebrew) — implemented as a separate thin entry (`content_page.js`) over the shared `content_runtime.mjs`
- All invocation paths (icon, menu, shortcut) share one `invoke()`; restricted pages (chrome://) fail with a console warning instead of an unhandled rejection

Tests: 41 pass — manifest tests lock in the new `contextMenus` permission and the declared command. Build green with the new entry point.