### PR TITLE
English-first UI labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,19 +36,22 @@
 
 ### New
 
-- **Right-click menu**: "הוסף ניקוד" on a selection, "הוסף ניקוד לכל הדף"
-  anywhere, and "הסר ניקוד" to take it back.
+- **Right-click menu**: "Add nikud" on a selection, "Add nikud to the whole
+  page" anywhere, and "Remove nikud" to take it back.
 - **Whole-page mode**: click the icon with nothing selected and the entire
   page gets niqqud.
-- **Remove / undo**: "הסר ניקוד" restores the original text exactly —
+- **Remove / undo**: "Remove nikud" restores the original text exactly —
   including text that already had partial niqqud before.
 - **Keyboard shortcut**: Ctrl+Shift+Y (⌘+Shift+Y on Mac), remappable at
   chrome://extensions/shortcuts.
 - **Works in text boxes**: select text inside an input field, a comment box,
   or an editor like Gmail compose, and it gets niqqud in place.
-- **Paste page**: right-click the toolbar icon → "פתח דף ניקוד (הדבקה)" for a
+- **Paste page**: right-click the toolbar icon → "Open paste page" for a
   simple paste-and-copy page — useful in apps where the page can't be edited
   directly (Google Docs, Word Online).
+- **English-first interface**: menu items, buttons and messages are in
+  English (with Hebrew alongside where it helps) — the extension is for
+  people learning Hebrew, so the controls shouldn't require it.
 
 ### Privacy
 

--- a/background.js
+++ b/background.js
@@ -86,24 +86,25 @@ chrome.action.onClicked.addListener(tab => invoke(tab, 'content.js'));
 
 chrome.runtime.onInstalled.addListener(() => {
     chrome.contextMenus.removeAll(() => {
+        // English-first labels: the audience is Hebrew learners.
         chrome.contextMenus.create({
             id: 'nekudot-selection',
-            title: 'הוסף ניקוד',
+            title: 'Add nikud (הוסף ניקוד)',
             contexts: ['selection'],
         });
         chrome.contextMenus.create({
             id: 'nekudot-page',
-            title: 'הוסף ניקוד לכל הדף',
+            title: 'Add nikud to the whole page',
             contexts: ['page'],
         });
         chrome.contextMenus.create({
             id: 'nekudot-remove',
-            title: 'הסר ניקוד',
+            title: 'Remove nikud (הסר ניקוד)',
             contexts: ['selection', 'page'],
         });
         chrome.contextMenus.create({
             id: 'nekudot-paste-page',
-            title: 'פתח דף ניקוד (הדבקה)',
+            title: 'Open paste page (works in Google Docs etc.)',
             contexts: ['action'],
         });
     });

--- a/content.js
+++ b/content.js
@@ -66,7 +66,7 @@ function setNekudot() {
 
     const {pending, segments} = collectSegments(nodes, range);
     if (segments.length === 0) {
-        if (!range) showToast('לא נמצא טקסט בעברית בדף');
+        if (!range) showToast('Nekudot: no Hebrew text found on this page');
         return;
     }
     requestDiacritics(segments, pending);

--- a/content_runtime.mjs
+++ b/content_runtime.mjs
@@ -33,7 +33,6 @@ function collectTextNodes(root, range = null) {
 function showToast(message) {
     const toast = document.createElement('div');
     toast.textContent = message;
-    toast.setAttribute('dir', 'rtl');
     toast.style.cssText = 'position:fixed;top:16px;right:16px;z-index:2147483647;' +
         'background:#333;color:#fff;padding:10px 16px;border-radius:6px;' +
         'font:14px sans-serif;box-shadow:0 2px 8px rgba(0,0,0,.35)';
@@ -78,7 +77,7 @@ function requestDiacritics(segments, pending) {
             port.disconnect();
         } else if (msg.type === 'fatal') {
             console.error('Nekudot failed:', msg.reason);
-            showToast('הוספת הניקוד נכשלה');
+            showToast('Nekudot: adding nikud failed');
             port.disconnect();
         }
     });

--- a/paste.html
+++ b/paste.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html lang="he" dir="rtl">
+<html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>נקודות — ניקוד טקסט</title>
+    <title>Nekudot — Add Nikud to Text</title>
     <style>
         :root {
             color-scheme: light dark;
@@ -22,7 +22,8 @@
             color: var(--fg);
             font: 16px/1.6 sans-serif;
         }
-        h1 { font-size: 20px; margin: 0 0 16px; }
+        h1 { font-size: 20px; margin: 0 0 4px; }
+        .subtitle { margin: 0 0 16px; font-size: 14px; opacity: .75; }
         textarea {
             width: 100%;
             min-height: 160px;
@@ -51,15 +52,16 @@
     </style>
 </head>
 <body>
-<h1>ניקוד טקסט</h1>
-<textarea id="input" placeholder="הדביקו כאן טקסט בעברית..." autofocus></textarea>
+<h1>Add Nikud to Text (ניקוד)</h1>
+<p class="subtitle">Paste Hebrew text below — useful in apps that can't be edited in place, like Google Docs or Word Online.</p>
+<textarea id="input" dir="rtl" placeholder="Paste Hebrew text here..." autofocus></textarea>
 <div class="row">
-    <button id="run">נַקֵּד</button>
+    <button id="run">Add Nikud (נַקֵּד)</button>
     <span id="status"></span>
 </div>
-<textarea id="output" readonly placeholder="הטקסט המנוקד יופיע כאן"></textarea>
+<textarea id="output" dir="rtl" readonly placeholder="The text with nikud will appear here"></textarea>
 <div class="row">
-    <button id="copy" class="secondary" disabled>העתקה</button>
+    <button id="copy" class="secondary" disabled>Copy</button>
 </div>
 <script type="module" src="paste.js"></script>
 </body>

--- a/paste.js
+++ b/paste.js
@@ -13,7 +13,7 @@ run.addEventListener('click', () => {
     if (!text.trim()) return;
 
     run.disabled = true;
-    status.textContent = 'מנקד...';
+    status.textContent = 'Adding nikud...';
     output.value = '';
     copy.disabled = true;
 
@@ -27,7 +27,7 @@ run.addEventListener('click', () => {
             copy.disabled = !output.value;
             port.disconnect();
         } else if (msg.type === 'fatal') {
-            status.textContent = 'הניקוד נכשל: ' + msg.reason;
+            status.textContent = 'Failed: ' + msg.reason;
             run.disabled = false;
             port.disconnect();
         }
@@ -37,6 +37,6 @@ run.addEventListener('click', () => {
 
 copy.addEventListener('click', async () => {
     await navigator.clipboard.writeText(output.value);
-    status.textContent = 'הועתק!';
+    status.textContent = 'Copied!';
     setTimeout(() => { status.textContent = ''; }, 2000);
 });


### PR DESCRIPTION
Stacked on #25. The extension is for people learning Hebrew — Hebrew-only controls make it harder to use. All user-facing labels are now English-first, with Hebrew alongside where it aids recognition:

- **Context menu**: 'Add nikud (הוסף ניקוד)', 'Add nikud to the whole page', 'Remove nikud (הסר ניקוד)', 'Open paste page (works in Google Docs etc.)'
- **Paste page**: English title/hint/buttons/statuses ('Add Nikud (נַקֵּד)', 'Copy', 'Adding nikud...', 'Copied!'); the input/output text areas remain RTL for the Hebrew content itself
- **Toasts**: 'Nekudot: adding nikud failed', 'Nekudot: no Hebrew text found on this page' (and no longer RTL-styled)

CHANGELOG.md updated to match, plus a 'New' bullet about the English-first interface. 55 tests + build green.