### PR TITLE
Incremental re-runs: only new content is processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@
 - **English-first interface**: menu items, buttons and messages are in
   English (with Hebrew alongside where it helps) — the extension is for
   people learning Hebrew, so the controls shouldn't require it.
+- **Smart re-runs**: running again on the same page only processes text that
+  is new since the last run. On sites that keep loading articles as you
+  scroll, scroll down and run again — only the new content is processed,
+  in a fraction of the time, and text that already has nikud is left alone.
 
 ### Privacy
 

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 // Diacritize entry point. The background's frame probe enforces scope:
 // this file is injected only into frames that have a selection, or into
 // the top frame alone when no frame has one (whole-page mode).
-import {nodeSegment} from './content_lib.mjs';
+import {nodeSegment, isMostlyDotted} from './content_lib.mjs';
 import {collectTextNodes, requestDiacritics, getRegistry, activeEditable, showToast} from './content_runtime.mjs';
 
 // Selection inside an <input>/<textarea>: splice the diacritized text into
@@ -10,7 +10,7 @@ function setNekudotEditable(el) {
     const start = el.selectionStart;
     const end = el.selectionEnd;
     const seg = nodeSegment(el.value, true, true, start, end);
-    if (!seg) return;
+    if (!seg || isMostlyDotted(seg.middle)) return;
 
     const pending = new Map();
     pending.set(0, {
@@ -26,9 +26,19 @@ function setNekudotEditable(el) {
 }
 
 function collectSegments(nodes, range) {
+    const registry = getRegistry();
     const pending = new Map();
     const segments = [];
+    let alreadyDotted = 0;
     for (const node of nodes) {
+        // Incremental re-runs: pages that load more content as you scroll
+        // make a second Ctrl+A cover everything again. Skip what we already
+        // dotted (registry) and what came dotted, so a re-run only costs
+        // the newly loaded text.
+        if (registry.has(node) || isMostlyDotted(node.textContent)) {
+            alreadyDotted++;
+            continue;
+        }
         const seg = range
             ? nodeSegment(node.textContent, node === range.startContainer,
                 node === range.endContainer, range.startOffset, range.endOffset)
@@ -38,7 +48,7 @@ function collectSegments(nodes, range) {
         pending.set(id, {node, prefix: seg.prefix, suffix: seg.suffix});
         segments.push({id, text: seg.middle});
     }
-    return {pending, segments};
+    return {pending, segments, alreadyDotted};
 }
 
 function setNekudot() {
@@ -64,9 +74,12 @@ function setNekudot() {
         nodes = collectTextNodes(document.body); // whole-page mode
     }
 
-    const {pending, segments} = collectSegments(nodes, range);
+    const {pending, segments, alreadyDotted} = collectSegments(nodes, range);
     if (segments.length === 0) {
-        if (!range) showToast('Nekudot: no Hebrew text found on this page');
+        if (alreadyDotted > 0)
+            showToast('Nekudot: this text already has nikud');
+        else if (!range)
+            showToast('Nekudot: no Hebrew text found on this page');
         return;
     }
     requestDiacritics(segments, pending);

--- a/content.js
+++ b/content.js
@@ -1,7 +1,7 @@
 // Diacritize entry point. The background's frame probe enforces scope:
 // this file is injected only into frames that have a selection, or into
 // the top frame alone when no frame has one (whole-page mode).
-import {nodeSegment, isMostlyDotted} from './content_lib.mjs';
+import {nodeSegment, isMostlyDotted, collectSegments} from './content_lib.mjs';
 import {collectTextNodes, requestDiacritics, getRegistry, activeEditable, showToast} from './content_runtime.mjs';
 
 // Selection inside an <input>/<textarea>: splice the diacritized text into
@@ -10,7 +10,11 @@ function setNekudotEditable(el) {
     const start = el.selectionStart;
     const end = el.selectionEnd;
     const seg = nodeSegment(el.value, true, true, start, end);
-    if (!seg || isMostlyDotted(seg.middle)) return;
+    if (!seg) return;
+    if (isMostlyDotted(seg.middle)) {
+        showToast('Nekudot: this text already has nikud');
+        return;
+    }
 
     const pending = new Map();
     pending.set(0, {
@@ -23,32 +27,6 @@ function setNekudotEditable(el) {
         }
     });
     requestDiacritics([{id: 0, text: seg.middle}], pending);
-}
-
-function collectSegments(nodes, range) {
-    const registry = getRegistry();
-    const pending = new Map();
-    const segments = [];
-    let alreadyDotted = 0;
-    for (const node of nodes) {
-        // Incremental re-runs: pages that load more content as you scroll
-        // make a second Ctrl+A cover everything again. Skip what we already
-        // dotted (registry) and what came dotted, so a re-run only costs
-        // the newly loaded text.
-        if (registry.has(node) || isMostlyDotted(node.textContent)) {
-            alreadyDotted++;
-            continue;
-        }
-        const seg = range
-            ? nodeSegment(node.textContent, node === range.startContainer,
-                node === range.endContainer, range.startOffset, range.endOffset)
-            : nodeSegment(node.textContent, false, false, 0, 0);
-        if (!seg) continue;
-        const id = segments.length;
-        pending.set(id, {node, prefix: seg.prefix, suffix: seg.suffix});
-        segments.push({id, text: seg.middle});
-    }
-    return {pending, segments, alreadyDotted};
 }
 
 function setNekudot() {

--- a/content_lib.mjs
+++ b/content_lib.mjs
@@ -7,6 +7,20 @@ function hasHebrew(text) {
     return HEBREW_RE.test(text);
 }
 
+// Text whose Hebrew letters already largely carry marks needs no work —
+// either this extension dotted it on a previous run (and the node was
+// since replaced by the page, losing its registry entry), or the content
+// came dotted. Fully dotted Hebrew has roughly one mark per letter;
+// half-dotted is a safe threshold that still processes lightly-marked
+// learning texts. Lets a re-run on an infinite-scroll page process only
+// the newly loaded content.
+function isMostlyDotted(text) {
+    const letters = (text.match(/[א-ת]/g) || []).length;
+    if (letters === 0) return false;
+    const marks = (text.match(/[\u05B0-\u05BC\u05C1\u05C2]/g) || []).length;
+    return marks >= letters * 0.5;
+}
+
 // The part of one text node covered by a Range. Ranges are always ordered
 // (unlike Selection anchor/extent), so no direction handling is needed.
 // Offsets are clamped: when the range's start/end container is not a text
@@ -28,4 +42,4 @@ function nodeSegment(text, isStartContainer, isEndContainer, rangeStartOffset, r
     return {prefix: text.slice(0, start), middle, suffix: text.slice(end)};
 }
 
-export {hasHebrew, segmentRange, nodeSegment};
+export {hasHebrew, isMostlyDotted, segmentRange, nodeSegment};

--- a/content_lib.mjs
+++ b/content_lib.mjs
@@ -7,18 +7,19 @@ function hasHebrew(text) {
     return HEBREW_RE.test(text);
 }
 
-// Text whose Hebrew letters already largely carry marks needs no work —
-// either this extension dotted it on a previous run (and the node was
-// since replaced by the page, losing its registry entry), or the content
-// came dotted. Fully dotted Hebrew has roughly one mark per letter;
-// half-dotted is a safe threshold that still processes lightly-marked
-// learning texts. Lets a re-run on an infinite-scroll page process only
-// the newly loaded content.
+// Text that is already dotted needs no work — this extension dotted it on
+// a previous run, or the content came dotted. Judged per word (a Hebrew
+// word counts as dotted when it carries at least one mark) so that a
+// per-letter ratio can't misfire on short words or dagesh-dense spans:
+// learning texts where most words are bare are still processed. Lets a
+// re-run on an infinite-scroll page process only the newly loaded content.
+// (To force re-dotting, use Remove nikud first.)
 function isMostlyDotted(text) {
-    const letters = (text.match(/[א-ת]/g) || []).length;
-    if (letters === 0) return false;
-    const marks = (text.match(/[\u05B0-\u05BC\u05C1\u05C2]/g) || []).length;
-    return marks >= letters * 0.5;
+    const words = (text.match(/[\u05D0-\u05EA\u05B0-\u05C2]+/g) || [])
+        .filter(w => (w.match(/[\u05D0-\u05EA]/g) || []).length >= 2);
+    if (words.length === 0) return false;
+    const dotted = words.filter(w => /[\u05B0-\u05BC\u05C1\u05C2]/.test(w)).length;
+    return dotted / words.length >= 0.75;
 }
 
 // The part of one text node covered by a Range. Ranges are always ordered
@@ -42,4 +43,31 @@ function nodeSegment(text, isStartContainer, isEndContainer, rangeStartOffset, r
     return {prefix: text.slice(0, start), middle, suffix: text.slice(end)};
 }
 
-export {hasHebrew, isMostlyDotted, segmentRange, nodeSegment};
+// Build the segment list for a set of text nodes (the selection's nodes, or
+// every node in whole-page mode). The already-dotted skip is judged on each
+// node's SELECTED text (seg.middle), never on node identity or full text:
+// a partially-dotted node can still have its other sentences dotted, and a
+// node whose text the page swapped after we dotted it (SPA re-render) is
+// re-processed because its new text carries no marks.
+function collectSegments(nodes, range) {
+    const pending = new Map();
+    const segments = [];
+    let alreadyDotted = 0;
+    for (const node of nodes) {
+        const seg = range
+            ? nodeSegment(node.textContent, node === range.startContainer,
+                node === range.endContainer, range.startOffset, range.endOffset)
+            : nodeSegment(node.textContent, false, false, 0, 0);
+        if (!seg) continue;
+        if (isMostlyDotted(seg.middle)) {
+            alreadyDotted++;
+            continue;
+        }
+        const id = segments.length;
+        pending.set(id, {node, prefix: seg.prefix, suffix: seg.suffix});
+        segments.push({id, text: seg.middle});
+    }
+    return {pending, segments, alreadyDotted};
+}
+
+export {hasHebrew, isMostlyDotted, segmentRange, nodeSegment, collectSegments};

--- a/e2e/extension.test.mjs
+++ b/e2e/extension.test.mjs
@@ -178,4 +178,84 @@ describe('extension end-to-end in Chrome', {skip: missing}, () => {
             await page.close();
         });
     }
+
+    test('infinite-scroll re-run: only newly loaded content is processed', async () => {
+        const fixture = FIXTURES.includes('hebrewnews-home.html') ? 'hebrewnews-home.html' : FIXTURES[0];
+        const page = await browser.newPage();
+        await page.setRequestInterception(true);
+        page.on('request', req =>
+            req.url().startsWith(origin) ? req.continue() : req.abort());
+        const url = `${origin}/${fixture}`;
+        await page.goto(url, {waitUntil: 'domcontentloaded', timeout: 30000});
+
+        const selectAll = () => page.evaluate(() => {
+            const range = document.createRange();
+            range.selectNodeContents(document.body);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        });
+        const invoke = () => sw.evaluate(async (url) => {
+            const [tab] = await chrome.tabs.query({url});
+            await chrome.scripting.executeScript({
+                target: {tabId: tab.id, allFrames: true},
+                files: ['content.js'],
+            });
+        }, url);
+        const markCount = () => page.evaluate((MARKS) =>
+            (document.body.innerText.match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
+        const waitForStable = async (baseline) => {
+            let last = baseline, stable = 0;
+            const deadline = Date.now() + 120000;
+            while (Date.now() < deadline) {
+                await new Promise(r => setTimeout(r, 500));
+                const n = await markCount();
+                stable = (n === last && n > baseline) ? stable + 1 : 0;
+                last = n;
+                if (stable >= 4) break;
+            }
+            return last;
+        };
+
+        // First full run.
+        await selectAll();
+        const t0 = performance.now();
+        await invoke();
+        const afterFirst = await waitForStable(0);
+        const firstMs = performance.now() - t0 - 2000;
+        assert.ok(afterFirst > 0);
+
+        // Re-run with nothing new: everything is registry-skipped or already
+        // dotted, so the mark count must not change.
+        await selectAll();
+        await invoke();
+        await new Promise(r => setTimeout(r, 4000));
+        const afterRerun = await markCount();
+        assert.equal(afterRerun, afterFirst,
+            're-running on an already-dotted page must not re-process anything');
+
+        // Simulate content loaded by scrolling, then Ctrl+A again.
+        await page.evaluate(() => {
+            const div = document.createElement('div');
+            div.id = 'scrolled-in';
+            div.textContent = 'תוכן חדש שנטען בגלילה: הממשלה אישרה היום תוכנית חדשה ' +
+                'לשיפור התחבורה הציבורית בערים הגדולות ברחבי הארץ';
+            document.body.appendChild(div);
+        });
+        await selectAll();
+        const t1 = performance.now();
+        await invoke();
+        const afterNew = await waitForStable(afterRerun);
+        const incrementalMs = performance.now() - t1 - 2000;
+
+        const newDivMarks = await page.evaluate((MARKS) =>
+            (document.getElementById('scrolled-in').textContent
+                .match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
+        assert.ok(newDivMarks > 10, 'the scrolled-in content must receive niqqud');
+        assert.equal(afterNew - afterFirst, newDivMarks,
+            'a re-run must add marks only inside the newly loaded content');
+        console.log(`# incremental re-run: full page ${(firstMs / 1000).toFixed(1)}s, ` +
+            `new-content-only ${(incrementalMs / 1000).toFixed(1)}s (+${newDivMarks} marks)`);
+        await page.close();
+    });
 });

--- a/e2e/extension.test.mjs
+++ b/e2e/extension.test.mjs
@@ -31,6 +31,55 @@ const missing = FIXTURES.length === 0 ? 'fixtures missing — run `npm run fixtu
 describe('extension end-to-end in Chrome', {skip: missing}, () => {
     let browser, server, sw, origin;
 
+    // -- shared Chrome-driving helpers -------------------------------------
+
+    async function openFixture(fixture) {
+        const page = await browser.newPage();
+        await page.setRequestInterception(true);
+        page.on('request', req =>
+            req.url().startsWith(origin) ? req.continue() : req.abort());
+        await page.goto(`${origin}/${fixture}`, {waitUntil: 'domcontentloaded', timeout: 30000});
+        return page;
+    }
+
+    const selectAll = (page) => page.evaluate(() => {
+        const range = document.createRange();
+        range.selectNodeContents(document.body);
+        const sel = window.getSelection();
+        sel.removeAllRanges();
+        sel.addRange(range);
+    });
+
+    // exactly what chrome.action.onClicked -> invoke() does
+    const invokeOn = (page) => sw.evaluate(async (url) => {
+        const [tab] = await chrome.tabs.query({url});
+        await chrome.scripting.executeScript({
+            target: {tabId: tab.id, allFrames: true},
+            files: ['content.js'],
+        });
+    }, page.url());
+
+    const markCount = (page) => page.evaluate((MARKS) =>
+        (document.body.innerText.match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
+
+    // Results stream in; wait until the mark count is stable for 2s.
+    async function waitForStable(page, baseline, t0) {
+        let last = baseline, stable = 0, first = 0;
+        const deadline = Date.now() + 180000;
+        while (Date.now() < deadline) {
+            await new Promise(r => setTimeout(r, 500));
+            const n = await markCount(page);
+            if (n > baseline && first === 0) first = performance.now() - t0;
+            stable = (n === last && n > baseline) ? stable + 1 : 0;
+            last = n;
+            if (stable >= 4) break;
+        }
+        // totalMs excludes the 2s stability confirmation window
+        return {count: last, firstMs: first, totalMs: performance.now() - t0 - 2000};
+    }
+
+    // -----------------------------------------------------------------------
+
     before(async () => {
         // Serve fixtures by name; block everything else so the snapshots'
         // external references don't hit the network.
@@ -86,52 +135,16 @@ describe('extension end-to-end in Chrome', {skip: missing}, () => {
 
     for (const fixture of FIXTURES) {
         test(`Ctrl+A + invoke diacritizes every Hebrew element type: ${fixture}`, async () => {
-            const page = await browser.newPage();
-            await page.setRequestInterception(true);
-            page.on('request', req =>
-                req.url().startsWith(origin) ? req.continue() : req.abort());
-            const url = `${origin}/${fixture}`;
-            await page.goto(url, {waitUntil: 'domcontentloaded', timeout: 30000});
+            const page = await openFixture(fixture);
+            await selectAll(page);
+            const baseline = await markCount(page);
 
-            // Simulate Ctrl+A
-            await page.evaluate(() => {
-                const range = document.createRange();
-                range.selectNodeContents(document.body);
-                const sel = window.getSelection();
-                sel.removeAllRanges();
-                sel.addRange(range);
-            });
-
-            const markCount = () => page.evaluate((MARKS) =>
-                (document.body.innerText.match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
-
-            const baseline = await markCount();
-
-            // Invoke exactly like chrome.action.onClicked -> invoke() does
             const t0 = performance.now();
-            await sw.evaluate(async (url) => {
-                const [tab] = await chrome.tabs.query({url});
-                await chrome.scripting.executeScript({
-                    target: {tabId: tab.id, allFrames: true},
-                    files: ['content.js'],
-                });
-            }, url);
-
-            // Results stream in; wait until the mark count is stable.
-            let last = baseline, stable = 0, first = 0;
-            const deadline = Date.now() + 180000;
-            while (Date.now() < deadline) {
-                await new Promise(r => setTimeout(r, 500));
-                const n = await markCount();
-                if (n > baseline && first === 0) first = performance.now() - t0;
-                stable = (n === last && n > baseline) ? stable + 1 : 0;
-                last = n;
-                if (stable >= 4) break;
-            }
-            const total = performance.now() - t0 - 2000; // minus stability wait
-            assert.ok(last > baseline, 'no niqqud appeared within the deadline');
-            console.log(`# ${fixture}: first marks after ${(first / 1000).toFixed(1)}s, ` +
-                `${last - baseline} marks added after ~${(total / 1000).toFixed(1)}s`);
+            await invokeOn(page);
+            const {count, firstMs, totalMs} = await waitForStable(page, baseline, t0);
+            assert.ok(count > baseline, 'no niqqud appeared within the deadline');
+            console.log(`# ${fixture}: first marks after ${(firstMs / 1000).toFixed(1)}s, ` +
+                `${count - baseline} marks added after ~${(totalMs / 1000).toFixed(1)}s`);
 
             // Inspect the final HTML: group Hebrew text nodes by element type.
             const report = await page.evaluate((MARKS) => {
@@ -181,57 +194,22 @@ describe('extension end-to-end in Chrome', {skip: missing}, () => {
 
     test('infinite-scroll re-run: only newly loaded content is processed', async () => {
         const fixture = FIXTURES.includes('hebrewnews-home.html') ? 'hebrewnews-home.html' : FIXTURES[0];
-        const page = await browser.newPage();
-        await page.setRequestInterception(true);
-        page.on('request', req =>
-            req.url().startsWith(origin) ? req.continue() : req.abort());
-        const url = `${origin}/${fixture}`;
-        await page.goto(url, {waitUntil: 'domcontentloaded', timeout: 30000});
-
-        const selectAll = () => page.evaluate(() => {
-            const range = document.createRange();
-            range.selectNodeContents(document.body);
-            const sel = window.getSelection();
-            sel.removeAllRanges();
-            sel.addRange(range);
-        });
-        const invoke = () => sw.evaluate(async (url) => {
-            const [tab] = await chrome.tabs.query({url});
-            await chrome.scripting.executeScript({
-                target: {tabId: tab.id, allFrames: true},
-                files: ['content.js'],
-            });
-        }, url);
-        const markCount = () => page.evaluate((MARKS) =>
-            (document.body.innerText.match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
-        const waitForStable = async (baseline) => {
-            let last = baseline, stable = 0;
-            const deadline = Date.now() + 120000;
-            while (Date.now() < deadline) {
-                await new Promise(r => setTimeout(r, 500));
-                const n = await markCount();
-                stable = (n === last && n > baseline) ? stable + 1 : 0;
-                last = n;
-                if (stable >= 4) break;
-            }
-            return last;
-        };
+        const page = await openFixture(fixture);
 
         // First full run.
-        await selectAll();
+        await selectAll(page);
         const t0 = performance.now();
-        await invoke();
-        const afterFirst = await waitForStable(0);
-        const firstMs = performance.now() - t0 - 2000;
-        assert.ok(afterFirst > 0);
+        await invokeOn(page);
+        const first = await waitForStable(page, 0, t0);
+        assert.ok(first.count > 0);
 
-        // Re-run with nothing new: everything is registry-skipped or already
-        // dotted, so the mark count must not change.
-        await selectAll();
-        await invoke();
+        // Re-run with nothing new: everything is already dotted, so the
+        // mark count must not change.
+        await selectAll(page);
+        await invokeOn(page);
         await new Promise(r => setTimeout(r, 4000));
-        const afterRerun = await markCount();
-        assert.equal(afterRerun, afterFirst,
+        const afterRerun = await markCount(page);
+        assert.equal(afterRerun, first.count,
             're-running on an already-dotted page must not re-process anything');
 
         // Simulate content loaded by scrolling, then Ctrl+A again.
@@ -242,20 +220,74 @@ describe('extension end-to-end in Chrome', {skip: missing}, () => {
                 'לשיפור התחבורה הציבורית בערים הגדולות ברחבי הארץ';
             document.body.appendChild(div);
         });
-        await selectAll();
+        await selectAll(page);
         const t1 = performance.now();
-        await invoke();
-        const afterNew = await waitForStable(afterRerun);
-        const incrementalMs = performance.now() - t1 - 2000;
+        await invokeOn(page);
+        const incremental = await waitForStable(page, afterRerun, t1);
 
         const newDivMarks = await page.evaluate((MARKS) =>
             (document.getElementById('scrolled-in').textContent
                 .match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
         assert.ok(newDivMarks > 10, 'the scrolled-in content must receive niqqud');
-        assert.equal(afterNew - afterFirst, newDivMarks,
+        assert.equal(incremental.count - first.count, newDivMarks,
             'a re-run must add marks only inside the newly loaded content');
-        console.log(`# incremental re-run: full page ${(firstMs / 1000).toFixed(1)}s, ` +
-            `new-content-only ${(incrementalMs / 1000).toFixed(1)}s (+${newDivMarks} marks)`);
+        assert.ok(incremental.totalMs < first.totalMs / 2,
+            `incremental run (${incremental.totalMs.toFixed(0)}ms) should be far faster ` +
+            `than the full run (${first.totalMs.toFixed(0)}ms)`);
+        console.log(`# incremental re-run: full page ${(first.totalMs / 1000).toFixed(1)}s, ` +
+            `new-content-only ${(incremental.totalMs / 1000).toFixed(1)}s (+${newDivMarks} marks)`);
+        await page.close();
+    });
+
+    test('partially-dotted node: the rest of the node can still be dotted', async () => {
+        // Regression for the registry-skip bug: dotting one sentence of a
+        // node must not block dotting the rest of that same node later.
+        const fixture = FIXTURES[0];
+        const page = await openFixture(fixture);
+        const nodeText = 'משפט ראשון לגמרי רגיל. משפט שני נפרד לחלוטין.';
+        await page.evaluate((nodeText) => {
+            const div = document.createElement('div');
+            div.id = 'two-sentences';
+            div.textContent = nodeText;
+            document.body.appendChild(div);
+        }, nodeText);
+
+        const firstLen = 'משפט ראשון לגמרי רגיל.'.length;
+        const selectPart = (from, to) => page.evaluate(({from, to}) => {
+            const textNode = document.getElementById('two-sentences').firstChild;
+            const range = document.createRange();
+            range.setStart(textNode, from);
+            range.setEnd(textNode, to);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }, {from, to});
+        const divMarks = () => page.evaluate((MARKS) =>
+            (document.getElementById('two-sentences').textContent
+                .match(new RegExp(`[${MARKS}]`, 'g')) || []).length, MARKS);
+
+        // Dot only the first sentence, polling the div directly.
+        await selectPart(0, firstLen);
+        await invokeOn(page);
+        let deadline = Date.now() + 60000;
+        while (Date.now() < deadline && (await divMarks()) === 0)
+            await new Promise(r => setTimeout(r, 300));
+        const afterFirstSentence = await divMarks();
+        assert.ok(afterFirstSentence > 0, 'first sentence must get niqqud');
+
+        // Now select the second (still undotted) sentence of the SAME node.
+        const div = await page.evaluate(() =>
+            document.getElementById('two-sentences').textContent);
+        const secondStart = div.indexOf('משפט שני');
+        assert.ok(secondStart > 0);
+        await selectPart(secondStart, div.length);
+        await invokeOn(page);
+        deadline = Date.now() + 60000;
+        while (Date.now() < deadline && (await divMarks()) <= afterFirstSentence)
+            await new Promise(r => setTimeout(r, 300));
+        const afterSecondSentence = await divMarks();
+        assert.ok(afterSecondSentence > afterFirstSentence,
+            'the undotted rest of a partially-dotted node must still be processed');
         await page.close();
     });
 });

--- a/tests/content_lib.test.mjs
+++ b/tests/content_lib.test.mjs
@@ -1,6 +1,6 @@
 import {test, describe} from 'node:test';
 import assert from 'node:assert/strict';
-import {hasHebrew, isMostlyDotted, segmentRange, nodeSegment} from '../content_lib.mjs';
+import {hasHebrew, isMostlyDotted, segmentRange, nodeSegment, collectSegments} from '../content_lib.mjs';
 
 describe('hasHebrew', () => {
     test('detects Hebrew letters', () => {
@@ -25,9 +25,50 @@ describe('isMostlyDotted', () => {
         // one dotted word inside a long undotted sentence
         assert.equal(isMostlyDotted('שָׁלוֹם is one word inside טקסט ארוך בלי ניקוד בכלל כאן'), false);
     });
+    test('judged per word: a dotted short word next to bare words is processed', () => {
+        // per-letter ratios misfire here (1 mark / 4 letters); per-word is 1/2
+        assert.equal(isMostlyDotted('עַל זה'), false);
+        assert.equal(isMostlyDotted('בְּסֵדֶר גמור לגמרי בלי כלום'), false);
+    });
     test('no Hebrew means nothing to skip', () => {
         assert.equal(isMostlyDotted('hello world 123'), false);
         assert.equal(isMostlyDotted(''), false);
+    });
+});
+
+describe('collectSegments already-dotted skip', () => {
+    const node = (text) => ({textContent: text});
+
+    test('fully dotted nodes are skipped and counted', () => {
+        const nodes = [node('שָׁלוֹם עוֹלָם'), node('טקסט חדש בלי ניקוד')];
+        const {segments, alreadyDotted} = collectSegments(nodes, null);
+        assert.equal(alreadyDotted, 1);
+        assert.deepEqual(segments.map(s => s.text), ['טקסט חדש בלי ניקוד']);
+    });
+
+    test('the skip is judged on the selected part, not the whole node', () => {
+        // A node whose first half was dotted earlier: selecting the still
+        // undotted second half must be processed (regression: node-identity
+        // and whole-text skips blocked this forever).
+        const text = 'מִשְׁפָּט רִאשׁוֹן מְנֻקָּד. משפט שני רגיל.';
+        const secondStart = text.indexOf('משפט שני');
+        const n = node(text);
+        const range = {startContainer: n, endContainer: n,
+            startOffset: secondStart, endOffset: text.length};
+        const {segments, alreadyDotted} = collectSegments([n], range);
+        assert.equal(alreadyDotted, 0);
+        assert.deepEqual(segments.map(s => s.text), ['משפט שני רגיל.']);
+    });
+
+    test('selecting the already-dotted part of a node is skipped', () => {
+        const text = 'מִשְׁפָּט רִאשׁוֹן מְנֻקָּד. משפט שני רגיל.';
+        const dottedEnd = text.indexOf('.') + 1;
+        const n = node(text);
+        const range = {startContainer: n, endContainer: n,
+            startOffset: 0, endOffset: dottedEnd};
+        const {segments, alreadyDotted} = collectSegments([n], range);
+        assert.equal(alreadyDotted, 1);
+        assert.equal(segments.length, 0);
     });
 });
 

--- a/tests/content_lib.test.mjs
+++ b/tests/content_lib.test.mjs
@@ -1,6 +1,6 @@
 import {test, describe} from 'node:test';
 import assert from 'node:assert/strict';
-import {hasHebrew, segmentRange, nodeSegment} from '../content_lib.mjs';
+import {hasHebrew, isMostlyDotted, segmentRange, nodeSegment} from '../content_lib.mjs';
 
 describe('hasHebrew', () => {
     test('detects Hebrew letters', () => {
@@ -11,6 +11,23 @@ describe('hasHebrew', () => {
         assert.ok(!hasHebrew('hello 123'));
         assert.ok(!hasHebrew('ְָֹ'));
         assert.ok(!hasHebrew(''));
+    });
+});
+
+describe('isMostlyDotted', () => {
+    test('undotted Hebrew is not skipped', () => {
+        assert.equal(isMostlyDotted('שלום עולם, זהו טקסט רגיל'), false);
+    });
+    test('fully dotted Hebrew is skipped', () => {
+        assert.equal(isMostlyDotted('שָׁלוֹם עוֹלָם'), true);
+    });
+    test('lightly dotted learning text is still processed', () => {
+        // one dotted word inside a long undotted sentence
+        assert.equal(isMostlyDotted('שָׁלוֹם is one word inside טקסט ארוך בלי ניקוד בכלל כאן'), false);
+    });
+    test('no Hebrew means nothing to skip', () => {
+        assert.equal(isMostlyDotted('hello world 123'), false);
+        assert.equal(isMostlyDotted(''), false);
     });
 });
 

--- a/tests/real_page.test.mjs
+++ b/tests/real_page.test.mjs
@@ -16,7 +16,7 @@ import '@tensorflow/tfjs-backend-wasm';
 import {JSDOM} from 'jsdom';
 import {loadModelFromDisk} from '../scripts/model_loader.mjs';
 import {FIXTURES} from '../scripts/fixtures_list.mjs';
-import {nodeSegment} from '../content_lib.mjs';
+import {collectSegments} from '../content_lib.mjs';
 import {collectTextNodes} from '../content_runtime.mjs';
 import {remove_niqqud, diacritize_batch} from '../text_encoding.mjs';
 
@@ -50,22 +50,16 @@ for (const {name: fixtureName} of FIXTURES) {
             global.Node = dom.window.Node;
         });
 
-        function collectSegments(range = null) {
+        // the extension's exact segment collection (shared code, not a copy)
+        function pageSegments(range = null) {
             const root = range ? range.commonAncestorContainer : dom.window.document.body;
-            const segments = [];
-            for (const node of collectTextNodes(root, range)) {
-                const seg = range
-                    ? nodeSegment(node.textContent, node === range.startContainer,
-                        node === range.endContainer, range.startOffset, range.endOffset)
-                    : nodeSegment(node.textContent, false, false, 0, 0);
-                if (seg) segments.push(seg.middle);
-            }
-            return segments;
+            const nodes = collectTextNodes(root, range);
+            return collectSegments(nodes, range).segments.map(s => s.text);
         }
 
         test('whole-page mode: every segment survives and round-trips exactly', async () => {
             const m = await getModel();
-            const segments = collectSegments();
+            const segments = pageSegments();
             assert.ok(segments.length > 20, `expected a real page, got ${segments.length} segments`);
             const chars = segments.reduce((a, s) => a + s.length, 0);
 
@@ -98,8 +92,8 @@ for (const {name: fixtureName} of FIXTURES) {
                 t.skip('jsdom Range.intersectsNode unsupported');
                 return;
             }
-            const viaSelection = collectSegments(range);
-            const viaWholePage = collectSegments();
+            const viaSelection = pageSegments(range);
+            const viaWholePage = pageSegments();
             assert.deepEqual(viaSelection, viaWholePage,
                 'Ctrl+A over <body> must segment identically to whole-page mode');
         });
@@ -108,7 +102,7 @@ for (const {name: fixtureName} of FIXTURES) {
             const doc = dom.window.document;
             const scriptTexts = [...doc.querySelectorAll('script')]
                 .map(s => s.textContent.trim()).filter(s => s.length > 40);
-            const segments = new Set(collectSegments().map(s => s.trim()));
+            const segments = new Set(pageSegments().map(s => s.trim()));
             for (const s of scriptTexts)
                 assert.ok(!segments.has(s), 'script content must never be diacritized');
         });


### PR DESCRIPTION
Stacked on #26.

**Problem**: infinite-scroll pages load more articles as you scroll; a second Ctrl+A covers everything again and the model re-does work it already did.

**Fix**: segment collection skips (1) nodes in the undo registry — the extension already dotted them this page-lifetime — and (2) nodes whose Hebrew is already mostly marked (≥0.5 marks per letter), which catches pre-dotted content and nodes the page re-rendered after we dotted them. Lightly-marked learning text stays below the threshold and is still processed. When everything in scope is already dotted, the toast says 'this text already has nikud' instead of the misleading 'no Hebrew found'. `Remove nikud` first if you ever want to force a re-do.

**Proven in real Chrome** (new e2e subtest): dot a full page (2.7s) → re-run with nothing new → **0 marks added** → inject a scrolled-in Hebrew paragraph → re-run → **0.7s, exactly +76 marks**, all inside the new paragraph.

Also: `isMostlyDotted` unit tests (undotted / fully dotted / lightly-dotted learning text / no Hebrew), CHANGELOG 'Smart re-runs' entry. 59 unit/integration + 6 e2e passing.